### PR TITLE
[chore] 양방향 연관관계 및 Cascade 설정, Summary 옵션 추가

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/entity/PostEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/entity/PostEntity.java
@@ -1,9 +1,13 @@
 package org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
 import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -11,6 +15,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -46,4 +51,16 @@ public class PostEntity extends BaseEntity {
 	@OneToOne
 	@JoinColumn(name = "route_id", nullable = false)
 	private RouteEntity route;
+
+	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PostLikeEntity> postLikeEntityList = new ArrayList<>();
+
+	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PostSelectedCategoryOptionEntity> postSelectedCategoryOptionEntityList = new ArrayList<>();
+
+	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PostImageEntity> postImageEntityList = new ArrayList<>();
+
+	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PostCategoryOptionTop3Entity> postCategoryOptionTop3EntityList = new ArrayList<>();
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/entity/CategoryEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/entity/CategoryEntity.java
@@ -1,9 +1,14 @@
 package org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.locationtech.jts.geom.Polygon;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostImageEntity;
 import org.sopt.pawkey.backendapi.domain.region.domain.model.RegionType;
 import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -11,6 +16,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -33,4 +39,8 @@ public class CategoryEntity extends BaseEntity {
 
 	@Column(name = "category_name", nullable = false)
 	private String categoryName;
+
+
+	@OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<CategoryOptionEntity> categoryOptionEntityList = new ArrayList<>();
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/entity/CategoryOptionEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/entity/CategoryOptionEntity.java
@@ -1,10 +1,18 @@
 package org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.locationtech.jts.geom.Polygon;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostCategoryOptionTop3Entity;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostSelectedCategoryOptionEntity;
 import org.sopt.pawkey.backendapi.domain.region.domain.model.RegionType;
 import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewEntity;
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewSelectedCategoryOptionEntity;
 import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -15,6 +23,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -41,4 +50,13 @@ public class CategoryOptionEntity extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "category_id", nullable = false)
 	private CategoryEntity category;
+
+	@OneToMany(mappedBy = "categoryOption", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PostSelectedCategoryOptionEntity> postSelectedCategoryOptionEntityList = new ArrayList<>();
+
+	@OneToMany(mappedBy = "categoryOption", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<ReviewSelectedCategoryOptionEntity> reviewSelectedCategoryOptionEntityList = new ArrayList<>();
+
+	@OneToMany(mappedBy = "categoryOption", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PostCategoryOptionTop3Entity> postCategoryOptionTop3EntityList = new ArrayList<>();
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/entity/CategoryOptionEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/entity/CategoryOptionEntity.java
@@ -47,6 +47,9 @@ public class CategoryOptionEntity extends BaseEntity {
 	@Column(name = "option_text", nullable = false)
 	private String optionText;
 
+	@Column(name = "option_text_summary", nullable = false)
+	private String optionTextSummary;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "category_id", nullable = false)
 	private CategoryEntity category;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/image/infra/persistence/entity/ImageEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/image/infra/persistence/entity/ImageEntity.java
@@ -1,12 +1,19 @@
 package org.sopt.pawkey.backendapi.domain.image.infra.persistence.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostImageEntity;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
 import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -37,5 +44,8 @@ public class ImageEntity extends BaseEntity {
 
 	@Column(name = "height", nullable = false)
 	private int height;
+
+	@OneToMany(mappedBy = "image", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PostImageEntity> postImageEntityList = new ArrayList<>();
 
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/pet/infra/persistence/entity/PetEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/pet/infra/persistence/entity/PetEntity.java
@@ -1,9 +1,14 @@
 package org.sopt.pawkey.backendapi.domain.pet.infra.persistence.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.sopt.pawkey.backendapi.domain.image.infra.persistence.entity.ImageEntity;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostImageEntity;
 import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -12,6 +17,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -58,5 +64,8 @@ public class PetEntity extends BaseEntity {
 
 	@Column(name = "breed", length = 50)
 	private String breed;
+
+	@OneToMany(mappedBy = "pet", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PetTraitSelectedEntity> petTraitSelectedEntityList = new ArrayList<>();
 
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/pet/infra/persistence/entity/PetTraitCategoryEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/pet/infra/persistence/entity/PetTraitCategoryEntity.java
@@ -34,6 +34,6 @@ public class PetTraitCategoryEntity extends BaseEntity {
 	@Column(name = "name", nullable = false, length = 50)
 	private String name;
 
-	@OneToMany(mappedBy = "pet_trait_category", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(mappedBy = "petTraitCategory", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<PetTraitOptionEntity> petTraitOptionEntityList = new ArrayList<>();
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/pet/infra/persistence/entity/PetTraitCategoryEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/pet/infra/persistence/entity/PetTraitCategoryEntity.java
@@ -1,12 +1,17 @@
 package org.sopt.pawkey.backendapi.domain.pet.infra.persistence.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -28,4 +33,7 @@ public class PetTraitCategoryEntity extends BaseEntity {
 
 	@Column(name = "name", nullable = false, length = 50)
 	private String name;
+
+	@OneToMany(mappedBy = "pet_trait_category", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PetTraitOptionEntity> petTraitOptionEntityList = new ArrayList<>();
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/pet/infra/persistence/entity/PetTraitOptionEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/pet/infra/persistence/entity/PetTraitOptionEntity.java
@@ -38,11 +38,11 @@ public class PetTraitOptionEntity extends BaseEntity {
 	//PetTraitCategory 연관관계
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "pet_trait_category_id")
-	private PetTraitCategoryEntity category;
+	private PetTraitCategoryEntity petTraitCategory;
 
 	@Column(name = "option_text", nullable = false, length = 50)
 	private String optionText;
 
-	@OneToMany(mappedBy = "pet", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(mappedBy = "petTraitOption", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<PetTraitSelectedEntity> petTraitSelectedEntityList = new ArrayList<>();
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/pet/infra/persistence/entity/PetTraitOptionEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/pet/infra/persistence/entity/PetTraitOptionEntity.java
@@ -1,7 +1,11 @@
 package org.sopt.pawkey.backendapi.domain.pet.infra.persistence.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,6 +14,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -37,4 +42,7 @@ public class PetTraitOptionEntity extends BaseEntity {
 
 	@Column(name = "option_text", nullable = false, length = 50)
 	private String optionText;
+
+	@OneToMany(mappedBy = "pet", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PetTraitSelectedEntity> petTraitSelectedEntityList = new ArrayList<>();
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/infra/persistence/entity/RegionEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/infra/persistence/entity/RegionEntity.java
@@ -1,9 +1,15 @@
 package org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.locationtech.jts.geom.Polygon;
 import org.sopt.pawkey.backendapi.domain.region.domain.model.RegionType;
+import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -14,6 +20,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -45,6 +52,16 @@ public class RegionEntity extends BaseEntity {
 	@JoinColumn(name = "parent_id")
 	private RegionEntity parent;
 
+	@OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<RegionEntity> childrenRegionList = new ArrayList<>();
+
+
 	@Column(name = "area_geometry", columnDefinition = "geometry(Polygon, 4326)")
 	private Polygon areaGeometry;
+
+	@OneToMany(mappedBy = "region", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<UserEntity> userEntityList = new ArrayList<>();
+
+	@OneToMany(mappedBy = "region", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<RouteEntity> routeEntityList = new ArrayList<>();
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/infra/persistence/entity/RegionEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/infra/persistence/entity/RegionEntity.java
@@ -59,9 +59,10 @@ public class RegionEntity extends BaseEntity {
 	@Column(name = "area_geometry", columnDefinition = "geometry(Polygon, 4326)")
 	private Polygon areaGeometry;
 
-	@OneToMany(mappedBy = "region", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(mappedBy = "region", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
 	private List<UserEntity> userEntityList = new ArrayList<>();
 
-	@OneToMany(mappedBy = "region", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(mappedBy = "region", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
 	private List<RouteEntity> routeEntityList = new ArrayList<>();
 }
+

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/entity/ReviewEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/entity/ReviewEntity.java
@@ -1,13 +1,18 @@
 package org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.locationtech.jts.geom.Polygon;
 import org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity.CategoryOptionEntity;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostSelectedCategoryOptionEntity;
 import org.sopt.pawkey.backendapi.domain.region.domain.model.RegionType;
 import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
 import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -18,6 +23,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -45,4 +51,8 @@ public class ReviewEntity extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "route_id", nullable = false)
 	private RouteEntity route;
+
+
+	@OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<ReviewSelectedCategoryOptionEntity> reviewSelectedCategoryOptionEntityList = new ArrayList<>();
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/entity/ReviewSelectedCategoryOptionEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/entity/ReviewSelectedCategoryOptionEntity.java
@@ -38,4 +38,6 @@ public class ReviewSelectedCategoryOptionEntity extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "category_option_id", nullable = false)
 	private CategoryOptionEntity categoryOption;
+
+
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/UserEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/UserEntity.java
@@ -1,8 +1,16 @@
 package org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.pet.infra.persistence.entity.PetEntity;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewEntity;
 import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,6 +19,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -39,12 +48,21 @@ public class UserEntity extends BaseEntity {
 
 	private String loginId;
 
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PetEntity> petEntityList = new ArrayList<>();
+
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PostEntity> postEntityList = new ArrayList<>();
+
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<ReviewEntity> reviewEntityList = new ArrayList<>();
+
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PostLikeEntity> postLikeEntityList = new ArrayList<>();
+
+
 	public static UserEntity createEntity(String name, String loginId) {
 		return null;
-		// return UserEntity.builder()
-		// 	.name(name)
-		//
-		// 	.loginId(loginId)
-		// 	.build();
+
 	}
 }


### PR DESCRIPTION
## 📌 PR 제목
[chore] 양방향 연관관계 및 Cascade 설정, Summary 옵션 추가

---

## ✨ 요약 설명
엔티티 간 양방향 연관관계 설정, 연관 객체 삭제를 위한 Cascade 및 orphanRemoval 옵션 추가,
@Column(columnDefinition = "...")의 summary 등 상세 컬럼 제약 조건을 명시하였습니다.

---

## 🧾 변경 사항
- UserEntity, PostEntity, RegionEntity 등 주요 엔티티에 양방향 연관관계 필드(@OneToMany) 추가

- CascadeType.ALL, orphanRemoval = true 설정으로 연관 엔티티 자동 삭제/전이 적용

- PostCategoryEntity, PostEntity 등에 TEXT CHARACTER SET utf8mb4 및 summary 옵션 추가

---

## 📂 PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 기타 (엔티티 연관 설정 및 매핑 개선)

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 일대일 관계를 제외한 모든 연관관계에 대해 양방향 매핑을 추가했습니다.
실제 서비스 흐름에서 불필요하거나, 오히려 단방향이 더 적합한 관계가 있다면 제안 부탁드립니다.

- cascade = ALL, orphanRemoval = true 설정은 데이터 전파 및 삭제 일관성 유지를 고려하여 일괄 적용했으며, 이 부분도 실제 도메인 행위 기준으로 과한 설정이 있다면 조언 부탁드립니다.

- 연관관계 편의 메서드(addXXX, setXXX)는 현재 코드 구조와 통일성을 고려해 따로 작성하지 않았습니다. 실제 사용 시점에서 필요하다 판단되는 메서드가 있다면 말씀해 주세요. 추후 명확히 정리해서 추가하도록 하겠습니다.

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #27 
- Fix #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 게시글, 카테고리, 이미지, 반려동물, 지역, 리뷰, 사용자 등 여러 엔티티에서 연관된 항목 리스트(예: 좋아요, 이미지, 옵션, 선택 항목 등) 관리 기능이 추가되었습니다.
  * 각 엔티티에서 관련 항목의 일괄 관리 및 자동 삭제(고아 객체 제거) 기능이 활성화되었습니다.
  * 카테고리 옵션에 요약 텍스트 필드가 추가되었습니다.

* **기타 변경**
  * 일부 엔티티 생성 메서드 동작이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->