### PR TITLE
[feat] 지역 리스트 조회 api

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/controller/RegionController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/controller/RegionController.java
@@ -35,7 +35,7 @@ public class RegionController {
 	private final GetRegionListFacade getRegionListFacade;
 
 	@GetMapping
-	@Operation(summary = "지역구 리스트 조회", description = "지역구 리스트 조회 API입니다.", tags = {"Region"})
+	@Operation(summary = "지역구 리스트 조회", description = "검색 키워드로 지역구 리스트를 조회하는 API입니다.", tags = {"Region"})
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "지역구 리스트 조회")
 	})

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/controller/RegionController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/controller/RegionController.java
@@ -3,9 +3,13 @@ package org.sopt.pawkey.backendapi.domain.region.api.controller;
 import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
 
 import org.sopt.pawkey.backendapi.domain.region.api.dto.GetRegionCoordinatesResponse;
+import org.sopt.pawkey.backendapi.domain.region.api.dto.GetRegionListResponse;
+import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionListCommand;
+import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegionListResult;
 import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionCoordinatesCommand;
 import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegionCoordinatesResult;
-import org.sopt.pawkey.backendapi.domain.region.application.facade.command.GetRegionCoordinatesFacade;
+import org.sopt.pawkey.backendapi.domain.region.application.facade.query.GetRegionListFacade;
+import org.sopt.pawkey.backendapi.domain.region.application.facade.query.GetRegionCoordinatesFacade;
 import org.sopt.pawkey.backendapi.global.constants.AppConstants;
 import org.sopt.pawkey.backendapi.global.exception.BusinessException;
 import org.sopt.pawkey.backendapi.global.response.ApiResponse;
@@ -28,6 +32,22 @@ import lombok.RequiredArgsConstructor;
 public class RegionController {
 
 	private final GetRegionCoordinatesFacade getRegionCoordinatesFacade;
+	private final GetRegionListFacade getRegionListFacade;
+
+	@GetMapping
+	@Operation(summary = "지역구 리스트 조회", description = "지역구 리스트 조회 API입니다.", tags = {"Region"})
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "지역구 리스트 조회")
+	})
+	public ResponseEntity<ApiResponse<GetRegionListResponse>> getRegionList() {
+
+		GetRegionListCommand command = new GetRegionListCommand("강남구");
+		GetRegionListResult result = getRegionListFacade.execute(command);
+
+		return ResponseEntity.ok(
+			ApiResponse.success(GetRegionListResponse.from(result)));
+	}
+
 
 	@GetMapping("/{regionId}/geometry")
 	@Operation(summary = "지역 좌표 조회", description = "지역 좌표 조회 API입니다.", tags = {"Region"})

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/controller/RegionController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/controller/RegionController.java
@@ -4,12 +4,12 @@ import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
 
 import org.sopt.pawkey.backendapi.domain.region.api.dto.GetRegionCoordinatesResponse;
 import org.sopt.pawkey.backendapi.domain.region.api.dto.GetRegionListResponse;
-import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionListCommand;
-import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegionListResult;
 import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionCoordinatesCommand;
+import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionListCommand;
 import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegionCoordinatesResult;
-import org.sopt.pawkey.backendapi.domain.region.application.facade.query.GetRegionListFacade;
+import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegionListResult;
 import org.sopt.pawkey.backendapi.domain.region.application.facade.query.GetRegionCoordinatesFacade;
+import org.sopt.pawkey.backendapi.domain.region.application.facade.query.GetRegionListFacade;
 import org.sopt.pawkey.backendapi.global.constants.AppConstants;
 import org.sopt.pawkey.backendapi.global.exception.BusinessException;
 import org.sopt.pawkey.backendapi.global.response.ApiResponse;
@@ -47,7 +47,6 @@ public class RegionController {
 		return ResponseEntity.ok(
 			ApiResponse.success(GetRegionListResponse.from(result)));
 	}
-
 
 	@GetMapping("/{regionId}/geometry")
 	@Operation(summary = "지역 좌표 조회", description = "지역 좌표 조회 API입니다.", tags = {"Region"})

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/controller/RegionController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/controller/RegionController.java
@@ -2,8 +2,8 @@ package org.sopt.pawkey.backendapi.domain.region.api.controller;
 
 import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
 
-import org.sopt.pawkey.backendapi.domain.region.api.dto.GetRegionCoordinatesResponse;
-import org.sopt.pawkey.backendapi.domain.region.api.dto.GetRegionListResponse;
+import org.sopt.pawkey.backendapi.domain.region.api.dto.GetRegionCoordinatesResponseDto;
+import org.sopt.pawkey.backendapi.domain.region.api.dto.GetRegionListResponseDto;
 import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionCoordinatesCommand;
 import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionListCommand;
 import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegionCoordinatesResult;
@@ -39,13 +39,13 @@ public class RegionController {
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "지역구 리스트 조회")
 	})
-	public ResponseEntity<ApiResponse<GetRegionListResponse>> getRegionList() {
+	public ResponseEntity<ApiResponse<GetRegionListResponseDto>> getRegionList() {
 
 		GetRegionListCommand command = new GetRegionListCommand("강남구");
 		GetRegionListResult result = getRegionListFacade.execute(command);
 
 		return ResponseEntity.ok(
-			ApiResponse.success(GetRegionListResponse.from(result)));
+			ApiResponse.success(GetRegionListResponseDto.from(result)));
 	}
 
 	@GetMapping("/{regionId}/geometry")
@@ -53,7 +53,7 @@ public class RegionController {
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "지역 범위 좌표 조회"),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "조회 실패 (U40401 또는 R40401 에러코드 확인)", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BusinessException.class)))})
-	public ResponseEntity<ApiResponse<GetRegionCoordinatesResponse>> getRegionCoordinates(
+	public ResponseEntity<ApiResponse<GetRegionCoordinatesResponseDto>> getRegionCoordinates(
 		@RequestHeader(AppConstants.USER_ID_HEADER) Long userId,
 		@PathVariable("regionId") Long regionId
 	) {
@@ -62,6 +62,6 @@ public class RegionController {
 			GetRegionCoordinatesCommand.of(regionId));
 
 		return ResponseEntity.ok(
-			ApiResponse.success(GetRegionCoordinatesResponse.from(result)));
+			ApiResponse.success(GetRegionCoordinatesResponseDto.from(result)));
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/dto/GetRegionCoordinatesResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/dto/GetRegionCoordinatesResponseDto.java
@@ -7,12 +7,12 @@ import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegion
 import lombok.Builder;
 
 @Builder
-public record GetRegionCoordinatesResponse(
+public record GetRegionCoordinatesResponseDto(
 	String regionName,
 	Map<String, Object> geometryDto
 ) {
-	public static GetRegionCoordinatesResponse from(GetRegionCoordinatesResult result) {
-		return GetRegionCoordinatesResponse.builder()
+	public static GetRegionCoordinatesResponseDto from(GetRegionCoordinatesResult result) {
+		return GetRegionCoordinatesResponseDto.builder()
 			.regionName(result.regionName())
 			.geometryDto(result.geometryDto())
 			.build();

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/dto/GetRegionListResponse.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/dto/GetRegionListResponse.java
@@ -1,0 +1,45 @@
+package org.sopt.pawkey.backendapi.domain.region.api.dto;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegionListResult;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PROTECTED)
+public record GetRegionListResponse(
+	List<GuDongDto> guDongDtoList
+) {
+	public static GetRegionListResponse from(GetRegionListResult result) {
+		return GetRegionListResponse.builder()
+			.guDongDtoList(result.guDongDtoList().stream().map(GuDongDto::from).toList())
+			.build();
+	}
+
+	@Builder(access = AccessLevel.PROTECTED)
+	public record GuDongDto(
+		RegionDto gu,
+		List<RegionDto> dongs
+	) {
+		public static GuDongDto from(GetRegionListResult.GuDongDto guDongDto) {
+			return GuDongDto.builder()
+				.gu(RegionDto.from(guDongDto.gu()))
+				.dongs(guDongDto.dongs().stream().map(RegionDto::from).toList())
+				.build();
+		}
+	}
+
+	@Builder(access = AccessLevel.PROTECTED)
+	public record RegionDto(
+		Long id,
+		String name
+	) {
+		public static RegionDto from(GetRegionListResult.RegionDto regionDto) {
+			return RegionDto.builder()
+				.id(regionDto.id())
+				.name(regionDto.name())
+				.build();
+		}
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/dto/GetRegionListResponse.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/dto/GetRegionListResponse.java
@@ -9,21 +9,21 @@ import lombok.Builder;
 
 @Builder(access = AccessLevel.PROTECTED)
 public record GetRegionListResponse(
-	List<GuDongDto> guDongDtoList
+	List<DistrictDto> districtDtos
 ) {
 	public static GetRegionListResponse from(GetRegionListResult result) {
 		return GetRegionListResponse.builder()
-			.guDongDtoList(result.guDongDtoList().stream().map(GuDongDto::from).toList())
+			.districtDtos(result.districtDtos().stream().map(DistrictDto::from).toList())
 			.build();
 	}
 
 	@Builder(access = AccessLevel.PROTECTED)
-	public record GuDongDto(
+	public record DistrictDto(
 		RegionDto gu,
 		List<RegionDto> dongs
 	) {
-		public static GuDongDto from(GetRegionListResult.GuDongDto guDongDto) {
-			return GuDongDto.builder()
+		public static DistrictDto from(GetRegionListResult.DistrictDto guDongDto) {
+			return DistrictDto.builder()
 				.gu(RegionDto.from(guDongDto.gu()))
 				.dongs(guDongDto.dongs().stream().map(RegionDto::from).toList())
 				.build();

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/dto/GetRegionListResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/dto/GetRegionListResponseDto.java
@@ -8,11 +8,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 
 @Builder(access = AccessLevel.PROTECTED)
-public record GetRegionListResponse(
+public record GetRegionListResponseDto(
 	List<DistrictDto> districtDtos
 ) {
-	public static GetRegionListResponse from(GetRegionListResult result) {
-		return GetRegionListResponse.builder()
+	public static GetRegionListResponseDto from(GetRegionListResult result) {
+		return GetRegionListResponseDto.builder()
 			.districtDtos(result.districtDtos().stream().map(DistrictDto::from).toList())
 			.build();
 	}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/command/GetRegionListCommand.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/command/GetRegionListCommand.java
@@ -1,0 +1,6 @@
+package org.sopt.pawkey.backendapi.domain.region.application.dto.command;
+
+public record GetRegionListCommand(
+	String searchKeyword
+) {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/result/GetRegionListResult.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/result/GetRegionListResult.java
@@ -2,8 +2,6 @@ package org.sopt.pawkey.backendapi.domain.region.application.dto.result;
 
 import java.util.List;
 
-import javax.swing.plaf.synth.Region;
-
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 
 import lombok.AccessLevel;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/result/GetRegionListResult.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/result/GetRegionListResult.java
@@ -9,33 +9,35 @@ import lombok.Builder;
 
 @Builder(access = AccessLevel.PROTECTED)
 public record GetRegionListResult(
-	List<GuDongDto> guDongDtoList
+	List<DistrictDto> districtDtos
 ) {
 	public static GetRegionListResult from(List<RegionEntity> regions) {
 		if (regions == null) {
-			return GetRegionListResult.builder().guDongDtoList(List.of()).build();
+			return GetRegionListResult.builder().districtDtos(List.of()).build();
 		}
 
 		return GetRegionListResult
 			.builder()
-			.guDongDtoList(
+			.districtDtos(
 				regions.stream()
-					.map(GuDongDto::from)
+					.map(DistrictDto::from)
 					.toList()
 			)
 			.build();
 	}
 
 	@Builder(access = AccessLevel.PROTECTED)
-	public record GuDongDto(
+	public record DistrictDto(
 		RegionDto gu,
 		List<RegionDto> dongs
 	) {
-		public static GuDongDto from(RegionEntity region) {
-			return GuDongDto
+		public static DistrictDto from(RegionEntity region) {
+			return DistrictDto
 				.builder()
 				.gu(RegionDto.from(region))
-				.dongs(region.getChildrenRegionList().stream().map(RegionDto::from).toList())
+				.dongs(region.getChildrenRegionList().stream()
+					.map(RegionDto::from).toList()
+				)
 				.build();
 		}
 	}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/result/GetRegionListResult.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/result/GetRegionListResult.java
@@ -11,11 +11,15 @@ import lombok.Builder;
 public record GetRegionListResult(
 	List<GuDongDto> guDongDtoList
 ) {
-	public static GetRegionListResult from(List<RegionEntity> gusWithDongs) {
+	public static GetRegionListResult from(List<RegionEntity> regions) {
+		if (regions == null) {
+			return GetRegionListResult.builder().guDongDtoList(List.of()).build();
+		}
+
 		return GetRegionListResult
 			.builder()
 			.guDongDtoList(
-				gusWithDongs.stream()
+				regions.stream()
 					.map(GuDongDto::from)
 					.toList()
 			)

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/result/GetRegionListResult.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/result/GetRegionListResult.java
@@ -1,0 +1,53 @@
+package org.sopt.pawkey.backendapi.domain.region.application.dto.result;
+
+import java.util.List;
+
+import javax.swing.plaf.synth.Region;
+
+import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PROTECTED)
+public record GetRegionListResult(
+	List<GuDongDto> guDongDtoList
+) {
+	public static GetRegionListResult from(List<RegionEntity> gusWithDongs) {
+		return GetRegionListResult
+			.builder()
+			.guDongDtoList(
+				gusWithDongs.stream()
+					.map(GuDongDto::from)
+					.toList()
+			)
+			.build();
+	}
+
+	@Builder(access = AccessLevel.PROTECTED)
+	public record GuDongDto(
+		RegionDto gu,
+		List<RegionDto> dongs
+	) {
+		public static GuDongDto from(RegionEntity region) {
+			return GuDongDto
+				.builder()
+				.gu(RegionDto.from(region))
+				.dongs(region.getChildrenRegionList().stream().map(RegionDto::from).toList())
+				.build();
+		}
+	}
+
+	@Builder(access = AccessLevel.PROTECTED)
+	public record RegionDto(
+		Long id,
+		String name
+	) {
+		public static RegionDto from(RegionEntity entity) {
+			return RegionDto.builder()
+				.id(entity.getRegionId())
+				.name(entity.getRegionName())
+				.build();
+		}
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/facade/query/GetRegionCoordinatesFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/facade/query/GetRegionCoordinatesFacade.java
@@ -1,4 +1,4 @@
-package org.sopt.pawkey.backendapi.domain.region.application.facade.command;
+package org.sopt.pawkey.backendapi.domain.region.application.facade.query;
 
 import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionCoordinatesCommand;
 import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegionCoordinatesResult;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/facade/query/GetRegionListFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/facade/query/GetRegionListFacade.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 public class GetRegionListFacade {
 
 	private final RegionQueryService regionQueryService;
+
 	public GetRegionListResult execute(GetRegionListCommand command) {
 		List<RegionEntity> GusWithDongs = regionQueryService.searchGusWithRegion(command);
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/facade/query/GetRegionListFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/facade/query/GetRegionListFacade.java
@@ -7,11 +7,13 @@ import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegion
 import org.sopt.pawkey.backendapi.domain.region.application.service.query.RegionQueryService;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class GetRegionListFacade {
 
 	private final RegionQueryService regionQueryService;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/facade/query/GetRegionListFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/facade/query/GetRegionListFacade.java
@@ -1,0 +1,23 @@
+package org.sopt.pawkey.backendapi.domain.region.application.facade.query;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionListCommand;
+import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegionListResult;
+import org.sopt.pawkey.backendapi.domain.region.application.service.query.RegionQueryService;
+import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class GetRegionListFacade {
+
+	private final RegionQueryService regionQueryService;
+	public GetRegionListResult execute(GetRegionListCommand command) {
+		List<RegionEntity> GusWithDongs = regionQueryService.searchGusWithRegion(command);
+
+		return GetRegionListResult.from(GusWithDongs);
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/service/query/RegionQueryService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/service/query/RegionQueryService.java
@@ -1,0 +1,10 @@
+package org.sopt.pawkey.backendapi.domain.region.application.service.query;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionListCommand;
+import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
+
+public interface RegionQueryService {
+	List<RegionEntity> searchGusWithRegion(GetRegionListCommand command);
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/service/query/RegionQueryServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/service/query/RegionQueryServiceImpl.java
@@ -1,0 +1,23 @@
+package org.sopt.pawkey.backendapi.domain.region.application.service.query;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionListCommand;
+import org.sopt.pawkey.backendapi.domain.region.domain.RegionQueryRepository;
+import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RegionQueryServiceImpl implements RegionQueryService {
+
+	private final RegionQueryRepository regionQueryRepository;
+
+	@Override
+	public List<RegionEntity> searchGusWithRegion(GetRegionListCommand command) {
+
+		return regionQueryRepository.findGusByRegionNameWithChildren(command.searchKeyword());
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/service/query/RegionQueryServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/service/query/RegionQueryServiceImpl.java
@@ -18,6 +18,6 @@ public class RegionQueryServiceImpl implements RegionQueryService {
 	@Override
 	public List<RegionEntity> searchGusWithRegion(GetRegionListCommand command) {
 
-		return regionQueryRepository.findGusByRegionNameWithChildren(command.searchKeyword());
+		return regionQueryRepository.findDistrictByRegionNameWithChildren(command.searchKeyword());
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/domain/RegionQueryRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/domain/RegionQueryRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.pawkey.backendapi.domain.region.domain;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
+
+public interface RegionQueryRepository {
+	List<RegionEntity> findGusByRegionNameWithChildren(String keyword);
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/domain/RegionQueryRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/domain/RegionQueryRepository.java
@@ -5,5 +5,5 @@ import java.util.List;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 
 public interface RegionQueryRepository {
-	List<RegionEntity> findGusByRegionNameWithChildren(String keyword);
+	List<RegionEntity> findDistrictByRegionNameWithChildren(String keyword);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/infra/persistence/RegionQueryRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/infra/persistence/RegionQueryRepositoryImpl.java
@@ -1,0 +1,35 @@
+package org.sopt.pawkey.backendapi.domain.region.infra.persistence;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.sopt.pawkey.backendapi.domain.region.domain.RegionQueryRepository;
+import org.sopt.pawkey.backendapi.domain.region.domain.model.RegionType;
+import org.sopt.pawkey.backendapi.domain.region.exception.RegionBusinessException;
+import org.sopt.pawkey.backendapi.domain.region.exception.RegionErrorCode;
+import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.QRegionEntity;
+import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RegionQueryRepositoryImpl implements RegionQueryRepository {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<RegionEntity> findGusByRegionNameWithChildren(String keyword) {
+		QRegionEntity regionEntity = QRegionEntity.regionEntity;
+		QRegionEntity childRegion = new QRegionEntity("childRegion");
+
+		return queryFactory
+			.selectFrom(regionEntity)
+			.where(regionEntity.regionType.eq(RegionType.GU))
+			.where(regionEntity.regionName.eq(keyword))
+			.leftJoin(regionEntity.childrenRegionList, childRegion).fetchJoin()
+			.fetch();
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/infra/persistence/RegionQueryRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/infra/persistence/RegionQueryRepositoryImpl.java
@@ -1,12 +1,9 @@
 package org.sopt.pawkey.backendapi.domain.region.infra.persistence;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.sopt.pawkey.backendapi.domain.region.domain.RegionQueryRepository;
 import org.sopt.pawkey.backendapi.domain.region.domain.model.RegionType;
-import org.sopt.pawkey.backendapi.domain.region.exception.RegionBusinessException;
-import org.sopt.pawkey.backendapi.domain.region.exception.RegionErrorCode;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.QRegionEntity;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/infra/persistence/RegionQueryRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/infra/persistence/RegionQueryRepositoryImpl.java
@@ -18,7 +18,7 @@ public class RegionQueryRepositoryImpl implements RegionQueryRepository {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public List<RegionEntity> findGusByRegionNameWithChildren(String keyword) {
+	public List<RegionEntity> findDistrictByRegionNameWithChildren(String keyword) {
 		QRegionEntity regionEntity = QRegionEntity.regionEntity;
 		QRegionEntity childRegion = new QRegionEntity("childRegion");
 

--- a/src/main/java/org/sopt/pawkey/backendapi/global/config/WebConfig.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/config/WebConfig.java
@@ -17,6 +17,8 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(userHeaderInterceptor)
-			.addPathPatterns("/api/**"); // 적용하고 싶은 URL 경로
+			.addPathPatterns("/api/**")
+			.excludePathPatterns("/api/v1/regions")
+		; // 적용하고 싶은 URL 경로
 	}
 }


### PR DESCRIPTION
## 📌 PR 제목
[feat] 지역 리스트 조회 api

---

## ✨ 요약 설명
- 지역 리스트를 조회하는 api를 구현했습니다.
- queryService, queryRepository를 분리하였고, queryDSL을 통해 검색 로직을 구현했습니다.

---

## 🧾 변경 사항
- application 단에서 command로 이름에 따라 검색되도록 로직을 작성하였고, api 계층에서 "강남구"를 검색어로 지정하였습니다.
- 

---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
<img width="1302" height="827" alt="image" src="https://github.com/user-attachments/assets/9f161d39-0703-42cf-87ac-71653b200a39" />

- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #29 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * `/regions` 경로에 지역 목록을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다. 해당 엔드포인트를 통해 구(區)와 동(洞) 정보를 계층적으로 확인할 수 있습니다.

* **기타**
  * `/api/v1/regions` 경로가 사용자 헤더 인터셉터의 적용 대상에서 제외되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->