### PR TITLE
[feat] 좋아요한 산책 루트 게시글에 좋아요 취소 API 구현

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/controller/PostLikeController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/controller/PostLikeController.java
@@ -5,6 +5,7 @@ import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
 import org.sopt.pawkey.backendapi.domain.post.application.facade.command.PostLikeFacade;
 import org.sopt.pawkey.backendapi.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -37,6 +38,23 @@ public class PostLikeController {
 		@RequestHeader(USER_ID_HEADER) @NotNull Integer userId
 	) {
 		postLikeFacade.like(postId, userId.longValue());
+		return ResponseEntity.ok(ApiResponse.success(null));
+	}
+
+	@Operation(summary = "좋아요 취소", description = "산책 루트 게시글에 설정된 좋아요를 취소합니다.", tags = {"Posts"})
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "좋아요 저장 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(mediaType = "application/json")),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "본인 게시글에 좋아요 취소", content = @Content(mediaType = "application/json")),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 게시글", content = @Content(mediaType = "application/json")),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "좋아요 기록 없음", content = @Content(mediaType = "application/json")),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json"))})
+	@DeleteMapping("/{postId}")
+	public ResponseEntity<ApiResponse<Void>> cancelLike(
+		@PathVariable Long postId,
+		@RequestHeader(USER_ID_HEADER) @NotNull Integer userId) {
+
+		postLikeFacade.cancelLike(postId, userId.longValue());
 		return ResponseEntity.ok(ApiResponse.success(null));
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/command/PostLikeFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/command/PostLikeFacade.java
@@ -20,9 +20,15 @@ public class PostLikeFacade {
 
 	@Transactional
 	public void like(Long postId, Long userId) {
-		final UserEntity user = userService.findById(userId);
-		final PostEntity post = postService.findById(postId);
-
+		UserEntity user = userService.findById(userId);
+		PostEntity post = postService.findById(postId);
 		postLikeService.like(user, post);
+	}
+
+	@Transactional
+	public void cancelLike(Long postId, Long userId) {
+		UserEntity user = userService.findById(userId);
+		PostEntity post = postService.findById(postId);
+		postLikeService.cancelLike(user, post);
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/service/PostLikeService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/service/PostLikeService.java
@@ -10,4 +10,6 @@ public interface PostLikeService {
 	 * @param post 좋아요를 누를 게시글
 	 */
 	void like(final UserEntity user, final PostEntity post);
+
+	void cancelLike(UserEntity user, PostEntity post);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/service/PostLikeServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/service/PostLikeServiceImpl.java
@@ -17,43 +17,34 @@ public class PostLikeServiceImpl implements PostLikeService {
 
 	private final PostLikeRepository postLikeRepository;
 
-	/**
-	 * 본인 게시글이면 예외, 이미 좋아요가 존재하면 예외, 없으면 저장
-	 */
 	@Override
 	public void like(final UserEntity user, final PostEntity post) {
-		// 본인 게시글에 좋아요 금지
-		if (post.getUser().getUserId().equals(user.getUserId())) {
-			throw new PostLikeBusinessException(PostLikeErrorCode.CANNOT_LIKE_OWN_POST);
-		}
+		validateNotSelfLike(user, post);
 
-		// 이미 좋아요한 경우 예외
-		boolean exists = postLikeRepository.existsByUserIdAndPostId(user.getUserId(), post.getPostId());
-		if (exists) {
+		if (postLikeRepository.existsByUserIdAndPostId(user.getUserId(), post.getPostId())) {
 			throw new PostLikeBusinessException(PostLikeErrorCode.DUPLICATE_LIKE);
 		}
 
-		// 좋아요 저장
-		final PostLikeEntity postLike = PostLikeEntity.builder()
+		postLikeRepository.save(PostLikeEntity.builder()
 			.post(post)
 			.user(user)
-			.build();
-		postLikeRepository.save(postLike);
+			.build());
 	}
 
 	@Override
 	public void cancelLike(UserEntity user, PostEntity post) {
-		// 1. 먼저 좋아요 이력 확인 (없으면 404)
+		validateNotSelfLike(user, post);
+
 		PostLikeEntity postLike = postLikeRepository
 			.findByUserIdAndPostId(user.getUserId(), post.getPostId())
 			.orElseThrow(() -> new PostLikeBusinessException(PostLikeErrorCode.LIKE_NOT_FOUND));
 
-		// 2. 자기 글이면 예외 (좋아요는 눌렀지만 자기 글일 때)
+		postLikeRepository.delete(postLike);
+	}
+
+	private void validateNotSelfLike(UserEntity user, PostEntity post) {
 		if (post.getUser().getUserId().equals(user.getUserId())) {
 			throw new PostLikeBusinessException(PostLikeErrorCode.CANNOT_LIKE_OWN_POST);
 		}
-
-		// 3. 삭제
-		postLikeRepository.delete(postLike);
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/service/PostLikeServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/service/PostLikeServiceImpl.java
@@ -7,7 +7,6 @@ import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntit
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
 import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/domain/repository/PostLikeRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/domain/repository/PostLikeRepository.java
@@ -1,9 +1,15 @@
 package org.sopt.pawkey.backendapi.domain.post.domain.repository;
 
+import java.util.Optional;
+
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
 
 public interface PostLikeRepository {
 	PostLikeEntity save(PostLikeEntity postLike);
 
 	boolean existsByUserIdAndPostId(Long userId, Long postId);
+
+	Optional<PostLikeEntity> findByUserIdAndPostId(Long userId, Long postId);
+
+	void delete(PostLikeEntity postLike);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/exception/PostLikeErrorCode.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/exception/PostLikeErrorCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum PostLikeErrorCode implements ErrorCode {
 
 	DUPLICATE_LIKE("PL40901", "이미 좋아요를 누른 게시글입니다.", HttpStatus.CONFLICT),
-	CANNOT_LIKE_OWN_POST("PL40001", "자신의 게시글에는 좋아요를 누를 수 없습니다.", HttpStatus.BAD_REQUEST);
+	CANNOT_LIKE_OWN_POST("PL40001", "자신의 게시글에는 좋아요를 누르거나 취소할 수 없습니다.", HttpStatus.BAD_REQUEST),
+	LIKE_NOT_FOUND("PL40401", "좋아요를 누른 이력이 없습니다.", HttpStatus.NOT_FOUND);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/PostLikeRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/PostLikeRepositoryImpl.java
@@ -1,6 +1,8 @@
 // PostLikeRepositoryImpl.java
 package org.sopt.pawkey.backendapi.domain.post.infra.persistence.repository;
 
+import java.util.Optional;
+
 import org.sopt.pawkey.backendapi.domain.post.domain.repository.PostLikeRepository;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
 import org.springframework.stereotype.Repository;
@@ -22,5 +24,15 @@ public class PostLikeRepositoryImpl implements PostLikeRepository {
 	@Override
 	public boolean existsByUserIdAndPostId(Long userId, Long postId) {
 		return jpaRepository.existsByUser_UserIdAndPost_PostId(userId, postId);
+	}
+
+	@Override
+	public Optional<PostLikeEntity> findByUserIdAndPostId(Long userId, Long postId) {
+		return jpaRepository.findByUser_UserIdAndPost_PostId(userId, postId);
+	}
+
+	@Override
+	public void delete(PostLikeEntity postLike) {
+		jpaRepository.delete(postLike);
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/SpringDataPostLikeRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/SpringDataPostLikeRepository.java
@@ -1,8 +1,12 @@
 package org.sopt.pawkey.backendapi.domain.post.infra.persistence.repository;
 
+import java.util.Optional;
+
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SpringDataPostLikeRepository extends JpaRepository<PostLikeEntity, Long> {
 	boolean existsByUser_UserIdAndPost_PostId(Long userId, Long postId);
+
+	Optional<PostLikeEntity> findByUser_UserIdAndPost_PostId(Long userId, Long postId);
 }


### PR DESCRIPTION
## 📌 PR 제목
[feat] 좋아요한 산책 루트 게시글에 좋아요 취소 API 구현

---

## ✨ 요약 설명
게시글(Post)에 대한 좋아요 취소(PostLike 삭제) 기능을 구현했습니다.
**좋아요 이력이 없는 경우** 예외 처리, **본인 게시글일 경우 좋아요 불가 예외 처리**를 포함하며,
컨트롤러부터 퍼시스턴스까지 전체 계층을 구성했습니다.

---

## 🧾 변경 사항
- 게시글 좋아요 취소 API (DELETE /api/v1/likes/{postId}) 구현
- 좋아요 이력이 없는 경우 PostLikeBusinessException 예외 처리
- 본인 게시글인 경우 좋아요 및 취소 모두 예외 처리 추가
- PostLikeRepository, PostLikeService, PostLikeRepositoryImpl 구현
- 중복 로직 제거를 위한 validateNotSelfLike 메서드 추가
- Swagger 문서화 및 표준 응답 포맷 적용
---

## 📂 PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함
<img width="392" height="491" alt="image" src="https://github.com/user-attachments/assets/bd4b84d2-27ad-4a8b-8fe2-112bc9688644" />
<img width="393" height="494" alt="image" src="https://github.com/user-attachments/assets/22952cdb-3db2-429e-a3c4-607b8a754f01" />

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 본인 게시글에 대한 좋아요 금지 로직을 like와 cancelLike 양쪽에 중복 작성했는데, 현재는 서비스 내부 private 메서드(validateNotSelfLike)로 분리했습니다. 더 나은 책임 분리 구조가 있다면 피드백 부탁드립니다.
- 추후 좋아요 개수나 내가 좋아요 눌렀는지 확인하는 기능을 추가할 예정인데, 현재 구조에서 확장성 측면에서 부족한 부분이 있다면 조언 부탁드립니다.

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #43 
- Fix #43