### PR TITLE
[FEATURE] 저장된 산책 게시물 리스트 조회 API

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/domain/repository/PostLikeRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/domain/repository/PostLikeRepository.java
@@ -11,4 +11,7 @@ public interface PostLikeRepository {
 	boolean existsByUserIdAndPostId(Long userId, Long postId);
 
 	List<PostLikeEntity> findAllByUser(UserEntity user);
+
+	// fetch join된 결과 조회 메서드 선언
+	List<PostLikeEntity> findAllByUserWithPostAndImages(UserEntity user);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/domain/repository/PostLikeRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/domain/repository/PostLikeRepository.java
@@ -1,9 +1,14 @@
 package org.sopt.pawkey.backendapi.domain.post.domain.repository;
 
+import java.util.List;
+
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 
 public interface PostLikeRepository {
 	PostLikeEntity save(PostLikeEntity postLike);
 
 	boolean existsByUserIdAndPostId(Long userId, Long postId);
+
+	List<PostLikeEntity> findAllByUser(UserEntity user);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/domain/repository/PostLikeRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/domain/repository/PostLikeRepository.java
@@ -3,15 +3,12 @@ package org.sopt.pawkey.backendapi.domain.post.domain.repository;
 import java.util.List;
 
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
-import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 
 public interface PostLikeRepository {
 	PostLikeEntity save(PostLikeEntity postLike);
 
 	boolean existsByUserIdAndPostId(Long userId, Long postId);
 
-	List<PostLikeEntity> findAllByUser(UserEntity user);
-
 	// fetch join된 결과 조회 메서드 선언
-	List<PostLikeEntity> findAllByUserWithPostAndImages(UserEntity user);
+	List<PostLikeEntity> findAllByUserWithPostAndImages(Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/entity/PostEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/entity/PostEntity.java
@@ -1,6 +1,8 @@
 package org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.List;
 
 import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
@@ -58,8 +60,10 @@ public class PostEntity extends BaseEntity {
 	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<PostSelectedCategoryOptionEntity> postSelectedCategoryOptionEntityList = new ArrayList<>();
 
+	// Hibernate는 fetch join 시 여러 List 컬렉션을 동시에 조회할 수 없으므로, Set으로 바꿔 문제를 회피. Set은 중복을 허용하지 않고 순서가 없으며, Hibernate에서 fetch join 시 안정적
+	// 추후에 @OrderColumn(name = "order_idx") 같은 컬럼을 추가해 DB에 순서 정보를 저장할 수도 있음
 	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<PostImageEntity> postImageEntityList = new ArrayList<>();
+	private Set<PostImageEntity> postImageEntityList = new HashSet<>();
 
 	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
 	private List<PostCategoryOptionTop3Entity> postCategoryOptionTop3EntityList = new ArrayList<>();
@@ -81,7 +85,7 @@ public class PostEntity extends BaseEntity {
 			route,
 			new ArrayList<>(),
 			new ArrayList<>(),
-			new ArrayList<>(),
+			new HashSet<>(),
 			new ArrayList<>()
 		);
 	}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/entity/PostEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/entity/PostEntity.java
@@ -10,6 +10,7 @@ import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -60,7 +61,7 @@ public class PostEntity extends BaseEntity {
 	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<PostImageEntity> postImageEntityList = new ArrayList<>();
 
-	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
 	private List<PostCategoryOptionTop3Entity> postCategoryOptionTop3EntityList = new ArrayList<>();
 
 	public static PostEntity create(

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/PostLikeRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/PostLikeRepositoryImpl.java
@@ -1,8 +1,11 @@
 // PostLikeRepositoryImpl.java
 package org.sopt.pawkey.backendapi.domain.post.infra.persistence.repository;
 
+import java.util.List;
+
 import org.sopt.pawkey.backendapi.domain.post.domain.repository.PostLikeRepository;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
@@ -22,5 +25,10 @@ public class PostLikeRepositoryImpl implements PostLikeRepository {
 	@Override
 	public boolean existsByUserIdAndPostId(Long userId, Long postId) {
 		return jpaRepository.existsByUser_UserIdAndPost_PostId(userId, postId);
+	}
+
+	@Override
+	public List<PostLikeEntity> findAllByUser(UserEntity user) {
+		return jpaRepository.findAllByUser(user);
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/PostLikeRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/PostLikeRepositoryImpl.java
@@ -29,6 +29,11 @@ public class PostLikeRepositoryImpl implements PostLikeRepository {
 
 	@Override
 	public List<PostLikeEntity> findAllByUser(UserEntity user) {
-		return jpaRepository.findAllByUser(user);
+		return jpaRepository.findAllByUserWithPostAndImages(user);
+	}
+
+	@Override
+	public List<PostLikeEntity> findAllByUserWithPostAndImages(UserEntity user) {
+		return jpaRepository.findAllByUserWithPostAndImages(user);
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/PostLikeRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/PostLikeRepositoryImpl.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.sopt.pawkey.backendapi.domain.post.domain.repository.PostLikeRepository;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
-import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
@@ -28,12 +27,7 @@ public class PostLikeRepositoryImpl implements PostLikeRepository {
 	}
 
 	@Override
-	public List<PostLikeEntity> findAllByUser(UserEntity user) {
-		return jpaRepository.findAllByUserWithPostAndImages(user);
-	}
-
-	@Override
-	public List<PostLikeEntity> findAllByUserWithPostAndImages(UserEntity user) {
-		return jpaRepository.findAllByUserWithPostAndImages(user);
+	public List<PostLikeEntity> findAllByUserWithPostAndImages(Long userId) {
+		return jpaRepository.findAllByUserWithPostAndImages(userId);
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/SpringDataPostLikeRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/SpringDataPostLikeRepository.java
@@ -15,12 +15,8 @@ public interface SpringDataPostLikeRepository extends JpaRepository<PostLikeEnti
 	@Query("""
 		    select pl
 		    from PostLikeEntity pl
-		    join fetch pl.post p
-		    join fetch p.user u
-		    join fetch u.petEntityList pet
-		    left join fetch p.postImageEntityList images
-		    where pl.user = :user
+		    where pl.user.userId = :userId
 		""")
-	List<PostLikeEntity> findAllByUserWithPostAndImages(@Param("user") UserEntity user);
+	List<PostLikeEntity> findAllByUserWithPostAndImages(@Param("userId") Long userId);
 
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/SpringDataPostLikeRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/SpringDataPostLikeRepository.java
@@ -5,9 +5,22 @@ import java.util.List;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
 import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SpringDataPostLikeRepository extends JpaRepository<PostLikeEntity, Long> {
 	boolean existsByUser_UserIdAndPost_PostId(Long userId, Long postId);
 
-	List<PostLikeEntity> findAllByUser(UserEntity user);
+	// fetch join으로 연관된 Post, User, Pet, PostImage 한 번에 조회
+	@Query("""
+		    select pl
+		    from PostLikeEntity pl
+		    join fetch pl.post p
+		    join fetch p.user u
+		    join fetch u.petEntityList pet
+		    left join fetch p.postImageEntityList images
+		    where pl.user = :user
+		""")
+	List<PostLikeEntity> findAllByUserWithPostAndImages(@Param("user") UserEntity user);
+
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/SpringDataPostLikeRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/SpringDataPostLikeRepository.java
@@ -1,8 +1,13 @@
 package org.sopt.pawkey.backendapi.domain.post.infra.persistence.repository;
 
+import java.util.List;
+
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SpringDataPostLikeRepository extends JpaRepository<PostLikeEntity, Long> {
 	boolean existsByUser_UserIdAndPost_PostId(Long userId, Long postId);
+
+	List<PostLikeEntity> findAllByUser(UserEntity user);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
@@ -1,39 +1,49 @@
-// package org.sopt.pawkey.backendapi.domain.user.api.controller;
-//
-// import org.sopt.pawkey.backendapi.domain.user.api.dto.request.CreateUserRequestDto;
-// import org.sopt.pawkey.backendapi.domain.user.api.dto.response.CreateUserResponseDto;
-// import org.sopt.pawkey.backendapi.global.response.ApiResponse;
-// import org.springframework.http.ResponseEntity;
-// import org.springframework.web.bind.annotation.PostMapping;
-// import org.springframework.web.bind.annotation.RequestBody;
-// import org.springframework.web.bind.annotation.RequestMapping;
-// import org.springframework.web.bind.annotation.RestController;
-//
-// import io.swagger.v3.oas.annotations.Operation;
-// import io.swagger.v3.oas.annotations.media.Content;
-// import io.swagger.v3.oas.annotations.responses.ApiResponses;
-// import jakarta.validation.Valid;
-// import lombok.RequiredArgsConstructor;
-//
-// @RestController
-// @RequiredArgsConstructor
-// @RequestMapping(API_PREFIX + "/users")
-// public class UserController {
-//
-// 	private final UserRegisterFacade userRegisterFacade;
-//
-// 	@Operation(summary = "유저 생성", description = "회원가입 또는 유저 등록 API입니다.", tags = {"User"})
-// 	@ApiResponses({
-// 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "유저 생성 성공"),
-// 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(mediaType = "application/json")),
-// 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json"))})
-// 	@PostMapping
-// 	public ResponseEntity<ApiResponse<CreateUserResponseDto>> create(
-// 		@RequestBody @Valid CreateUserRequestDto createUserRequestDto) {
-//
-// 		final CreateUserResponseDto response = CreateUserResponseDto.from(
-// 			userRegisterFacade.execute(createUserRequestDto.toCommand()));
-//
-// 		return ResponseEntity.ok(ApiResponse.success(response));
-// 	}
-// }
+package org.sopt.pawkey.backendapi.domain.user.api.controller;
+
+import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.user.api.dto.response.LikedPostResponseDto;
+import org.sopt.pawkey.backendapi.domain.user.application.facade.query.UserLikedPostQueryFacade;
+import org.sopt.pawkey.backendapi.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(API_PREFIX + "/users")
+public class UserController {
+
+	// private final UserRegisterFacade userRegisterFacade;
+	//
+	// @Operation(summary = "유저 생성", description = "회원가입 또는 유저 등록 API입니다.", tags = {"User"})
+	// @ApiResponses({
+	// 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "유저 생성 성공"),
+	// 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(mediaType = "application/json")),
+	// 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json"))})
+	// @PostMapping
+	// public ResponseEntity<ApiResponse<CreateUserResponseDto>> create(
+	// 	@RequestBody @Valid CreateUserRequestDto createUserRequestDto) {
+	//
+	// 	final CreateUserResponseDto response = CreateUserResponseDto.from(
+	// 		userRegisterFacade.execute(createUserRequestDto.toCommand()));
+	//
+	// 	return ResponseEntity.ok(ApiResponse.success(response));
+	// }
+
+	private final UserLikedPostQueryFacade userLikedPostQueryFacade;
+
+	@GetMapping("/me/likes")
+	public ResponseEntity<ApiResponse<List<LikedPostResponseDto>>> getMyLikedPosts(
+		@RequestHeader("X-USER-ID") Long userId
+	) {
+		List<LikedPostResponseDto> likedPosts = userLikedPostQueryFacade.getLikedPosts(userId);
+		return ResponseEntity.ok(ApiResponse.success(likedPosts));
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/response/LikedPostResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/response/LikedPostResponseDto.java
@@ -1,0 +1,20 @@
+package org.sopt.pawkey.backendapi.domain.user.api.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record LikedPostResponseDto(
+	Long postId,
+	LocalDateTime createdAt,
+	Boolean isLiked,
+	String representativeImageUrl,
+	WriterDto writer,
+	List<String> descriptionTags
+) {
+
+	public record WriterDto(
+		Long userId,
+		String petName,
+		String petProfileImageUrl
+	) {}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
@@ -12,21 +12,23 @@ import org.sopt.pawkey.backendapi.domain.user.exception.UserErrorCode;
 import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.springframework.stereotype.Service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserLikedPostQueryFacade {
 
 	private final UserQueryRepository userQueryRepository;
 	private final UserLikedPostQueryService userLikedPostQueryService;
 
 	public List<LikedPostResponseDto> getLikedPosts(Long userId) {
+
 		UserEntity user = userQueryRepository.getUserByUserId(userId)
 			.orElseThrow(() -> new UserBusinessException(UserErrorCode.USER_NOT_FOUND));
 
-		// fetch join 메서드 사용
-		List<PostLikeEntity> likedPosts = userLikedPostQueryService.findLikedPostsByUserWithPostAndImages(user);
+		List<PostLikeEntity> likedPosts = userLikedPostQueryService.findLikedPostsByUserWithPostAndImages(userId);
 
 		return likedPosts.stream()
 			.map(postLike -> {

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
@@ -22,36 +22,34 @@ public class UserLikedPostQueryFacade {
 	private final UserLikedPostQueryService userLikedPostQueryService;
 
 	public List<LikedPostResponseDto> getLikedPosts(Long userId) {
-		// 1) Optional 안전 처리
 		UserEntity user = userQueryRepository.getUserByUserId(userId)
 			.orElseThrow(() -> new UserBusinessException(UserErrorCode.USER_NOT_FOUND));
 
-		// 2) 사용자가 좋아요한 PostLikeEntity 목록
-		List<PostLikeEntity> likedPosts = userLikedPostQueryService.findLikedPostsByUser(user);
+		// fetch join 메서드 사용
+		List<PostLikeEntity> likedPosts = userLikedPostQueryService.findLikedPostsByUserWithPostAndImages(user);
 
-		// 3) 각 PostLikeEntity → LikedPostResponseDto 변환
 		return likedPosts.stream()
 			.map(postLike -> {
 				var post = postLike.getPost();
 
-				String repImageUrl = String.valueOf(post.getPostImageEntityList()
+				String repImageUrl = post.getPostImageEntityList()
 					.stream()
-					.findFirst()                                         // 첫 번째 이미지
-					.map(PostImageEntity::getImage));
+					.findFirst()
+					.map(PostImageEntity::getImage)      // ImageEntity
+					.map(imageEntity -> imageEntity.getImageUrl())  // String URL
+					.orElse(null);
 
-				/* 작성자(UserEntity) 정보 */
 				var writer = post.getUser();
-				Long writerId              = writer.getUserId();
-				String writerPetName       = writer.getPet().getName();
-				String writerProfileImgUrl = writer.getPet().getProfileImage().getImageUrl();
+				Long writerId = writer.getUserId();
+				String writerPetName = writer.getPet() != null ? writer.getPet().getName() : null;
+				String writerProfileImgUrl = (writer.getPet() != null && writer.getPet().getProfileImage() != null) ?
+					writer.getPet().getProfileImage().getImageUrl() : null;
 
-				/* 설명 태그 → postCategoryOptionTop3EntityList의 getOptionText 문자열로 */
 				List<String> descriptionTags = post.getPostCategoryOptionTop3EntityList()
 					.stream()
 					.map(optionTop3 -> optionTop3.getCategoryOption().getOptionText())
 					.toList();
 
-				/* 일단 true.. */
 				boolean isLiked = true;
 
 				return new LikedPostResponseDto(

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
@@ -1,0 +1,72 @@
+package org.sopt.pawkey.backendapi.domain.user.application.facade.query;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostImageEntity;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
+import org.sopt.pawkey.backendapi.domain.user.api.dto.response.LikedPostResponseDto;
+import org.sopt.pawkey.backendapi.domain.user.application.service.UserLikedPostQueryService;
+import org.sopt.pawkey.backendapi.domain.user.domain.repository.UserQueryRepository;
+import org.sopt.pawkey.backendapi.domain.user.exception.UserBusinessException;
+import org.sopt.pawkey.backendapi.domain.user.exception.UserErrorCode;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserLikedPostQueryFacade {
+
+	private final UserQueryRepository userQueryRepository;
+	private final UserLikedPostQueryService userLikedPostQueryService;
+
+	public List<LikedPostResponseDto> getLikedPosts(Long userId) {
+		// 1) Optional 안전 처리
+		UserEntity user = userQueryRepository.getUserByUserId(userId)
+			.orElseThrow(() -> new UserBusinessException(UserErrorCode.USER_NOT_FOUND));
+
+		// 2) 사용자가 좋아요한 PostLikeEntity 목록
+		List<PostLikeEntity> likedPosts = userLikedPostQueryService.findLikedPostsByUser(user);
+
+		// 3) 각 PostLikeEntity → LikedPostResponseDto 변환
+		return likedPosts.stream()
+			.map(postLike -> {
+				var post = postLike.getPost();
+
+				String repImageUrl = String.valueOf(post.getPostImageEntityList()
+					.stream()
+					.findFirst()                                         // 첫 번째 이미지
+					.map(PostImageEntity::getImage));
+
+				/* 작성자(UserEntity) 정보 */
+				var writer = post.getUser();
+				Long writerId              = writer.getUserId();
+				String writerPetName       = writer.getPet().getName();
+				String writerProfileImgUrl = writer.getPet().getProfileImage().getImageUrl();
+
+				/* 설명 태그 → postCategoryOptionTop3EntityList의 getOptionText 문자열로 */
+				List<String> descriptionTags = post.getPostCategoryOptionTop3EntityList()
+					.stream()
+					.map(optionTop3 -> optionTop3.getCategoryOption().getOptionText())
+					.toList();
+
+				/* 일단 true.. */
+				boolean isLiked = true;
+
+				return new LikedPostResponseDto(
+					post.getPostId(),
+					post.getCreatedAt(),
+					isLiked,
+					repImageUrl,
+					new LikedPostResponseDto.WriterDto(
+						writerId,
+						writerPetName,
+						writerProfileImgUrl
+					),
+					descriptionTags
+				);
+			})
+			.toList();
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserLikedPostQueryService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserLikedPostQueryService.java
@@ -1,0 +1,10 @@
+package org.sopt.pawkey.backendapi.domain.user.application.service;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+
+public interface UserLikedPostQueryService {
+	List<PostLikeEntity> findLikedPostsByUser(UserEntity user);
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserLikedPostQueryService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserLikedPostQueryService.java
@@ -3,10 +3,7 @@ package org.sopt.pawkey.backendapi.domain.user.application.service;
 import java.util.List;
 
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
-import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 
 public interface UserLikedPostQueryService {
-	List<PostLikeEntity> findLikedPostsByUser(UserEntity user);
-
-	List<PostLikeEntity> findLikedPostsByUserWithPostAndImages(UserEntity user);
+	List<PostLikeEntity> findLikedPostsByUserWithPostAndImages(Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserLikedPostQueryService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserLikedPostQueryService.java
@@ -7,4 +7,6 @@ import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntit
 
 public interface UserLikedPostQueryService {
 	List<PostLikeEntity> findLikedPostsByUser(UserEntity user);
+
+	List<PostLikeEntity> findLikedPostsByUserWithPostAndImages(UserEntity user);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserLikedPostQueryServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserLikedPostQueryServiceImpl.java
@@ -1,0 +1,24 @@
+package org.sopt.pawkey.backendapi.domain.user.application.service;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.post.domain.repository.PostLikeRepository;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserLikedPostQueryServiceImpl implements UserLikedPostQueryService {
+
+	private final PostLikeRepository postLikeRepository;
+
+	@Override
+	public List<PostLikeEntity> findLikedPostsByUser(UserEntity user) {
+		return postLikeRepository.findAllByUser(user);
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserLikedPostQueryServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserLikedPostQueryServiceImpl.java
@@ -19,6 +19,11 @@ public class UserLikedPostQueryServiceImpl implements UserLikedPostQueryService 
 
 	@Override
 	public List<PostLikeEntity> findLikedPostsByUser(UserEntity user) {
-		return postLikeRepository.findAllByUser(user);
+		return postLikeRepository.findAllByUserWithPostAndImages(user);
+	}
+
+	@Override
+	public List<PostLikeEntity> findLikedPostsByUserWithPostAndImages(UserEntity user) {
+		return postLikeRepository.findAllByUserWithPostAndImages(user);
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserLikedPostQueryServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserLikedPostQueryServiceImpl.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.sopt.pawkey.backendapi.domain.post.domain.repository.PostLikeRepository;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
-import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,12 +17,7 @@ public class UserLikedPostQueryServiceImpl implements UserLikedPostQueryService 
 	private final PostLikeRepository postLikeRepository;
 
 	@Override
-	public List<PostLikeEntity> findLikedPostsByUser(UserEntity user) {
-		return postLikeRepository.findAllByUserWithPostAndImages(user);
-	}
-
-	@Override
-	public List<PostLikeEntity> findLikedPostsByUserWithPostAndImages(UserEntity user) {
-		return postLikeRepository.findAllByUserWithPostAndImages(user);
+	public List<PostLikeEntity> findLikedPostsByUserWithPostAndImages(Long userId) {
+		return postLikeRepository.findAllByUserWithPostAndImages(userId);
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/UserEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/UserEntity.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.sopt.pawkey.backendapi.domain.pet.infra.persistence.entity.PetEntity;
-import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewEntity;
@@ -48,8 +47,9 @@ public class UserEntity extends BaseEntity {
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<PetEntity> petEntityList = new ArrayList<>();
 
-	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<PostEntity> postEntityList = new ArrayList<>();
+	public PetEntity getPet() {
+		return petEntityList.isEmpty() ? null : petEntityList.get(0);
+	}
 
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<ReviewEntity> reviewEntityList = new ArrayList<>();


### PR DESCRIPTION
## 📌 PR 제목
[FEATURE] 저장된 산책 게시물 리스트 조회 API

---

## ✨ 요약 설명
유저가 좋아요한 산책 게시물의 리스트를 조회하는 API를 구현했습니다.
게시물의 대표 이미지, 작성자의 반려동물 정보, 대표 태그(카테고리 Top3)를 포함하여 반환합니다.

---

## 🧾 변경 사항
- UserLikedPostQueryFacade에서 좋아요한 게시물 목록 조회 로직 구현
- LikedPostResponseDto 생성
- UserController에 /api/v1/users/me/posts/liked 엔드포인트 추가
- 게시물의 대표 이미지, 작성자 반려동물 정보, 태그(카테고리 Top3) 포함 반환
---

## 📂 PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함
<img width="513" height="673" alt="image" src="https://github.com/user-attachments/assets/3551f12d-f9f9-4043-aefc-28e552f9f0b2" />

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- postImageEntityList에 대해서 HashSet으로 바꾼 부분에 대해 괜찮을지 확인 부탁드리겠습니다!
- 리스트 조회 쿼리에 대해서 성능 상 이슈나 N+1 문제를 잘 해결했는지 검토 부탁드립니다.

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #48 
- Fix #48