### PR TITLE
[FEAT] 산책 루트 정보 조회 API

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/controller/RouteController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/controller/RouteController.java
@@ -2,16 +2,23 @@ package org.sopt.pawkey.backendapi.domain.routes.api.controller;
 
 import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
 
+import org.sopt.pawkey.backendapi.domain.routes.api.dto.GetRouteTrackingInfoResponse;
 import org.sopt.pawkey.backendapi.domain.routes.api.dto.RouteRegisterRequest;
 import org.sopt.pawkey.backendapi.domain.routes.api.dto.RouteRegisterResponse;
+import org.sopt.pawkey.backendapi.domain.routes.application.dto.command.GetRouteTrackingInfoCommand;
+import org.sopt.pawkey.backendapi.domain.routes.application.dto.result.GetRouteTrackingInfoResult;
 import org.sopt.pawkey.backendapi.domain.routes.application.dto.result.RouteRegisterResult;
 import org.sopt.pawkey.backendapi.domain.routes.application.facade.command.RouteRegisterFacade;
+import org.sopt.pawkey.backendapi.domain.routes.application.facade.query.GetRouteTrackingInfoFacade;
 import org.sopt.pawkey.backendapi.global.response.ApiResponse;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 public class RouteController {
 
 	private final RouteRegisterFacade routeRegisterFacade;
+	private final GetRouteTrackingInfoFacade getRouteTrackingInfoFacade;
 
 	@PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
 	@Operation(summary = "산책 루트 정보 등록", description = "산책 루트 정보 등록 API입니다.", tags = {"Route"})
@@ -45,5 +53,21 @@ public class RouteController {
 
 		return ResponseEntity.ok(
 			ApiResponse.success(RouteRegisterResponse.from(result)));
+	}
+
+	@GetMapping("/{routeId}/info")
+	@Operation(summary = "산책 루트 정보 조회", description = "게시물 등록 페이지에서 필요한 산책 루트 정보 조회하는 api입니다.", tags = {"Route"})
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "산책 루트 정보 조회 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "조회 실패 (U40401 또는 R40401 에러코드 확인)")})
+	public ResponseEntity<ApiResponse<GetRouteTrackingInfoResponse>> getTrackingInfo(
+		@RequestHeader(USER_ID_HEADER) Long userId,
+		@PathVariable("routeId") Long routeId
+	) {
+
+		GetRouteTrackingInfoResult result = getRouteTrackingInfoFacade.execute(userId,
+			new GetRouteTrackingInfoCommand(routeId));
+
+		return ResponseEntity.ok(ApiResponse.success(GetRouteTrackingInfoResponse.from(result)));
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/controller/RouteController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/controller/RouteController.java
@@ -58,7 +58,9 @@ public class RouteController {
 	@Operation(summary = "산책 루트 정보 조회", description = "게시물 등록 페이지에서 필요한 산책 루트 정보 조회하는 api입니다.", tags = {"Route"})
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "산책 루트 정보 조회 성공"),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "조회 실패 (U40401 또는 R40401 에러코드 확인)")})
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "조회 실패 (U40401, U40402 또는 R40401 에러코드 확인)"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 검증 실패 (R40301 에러코드 확인)")
+	})
 	public ResponseEntity<ApiResponse<GetRouteTrackingInfoResponse>> getTrackingInfo(
 		@RequestHeader(USER_ID_HEADER) Long userId,
 		@PathVariable("routeId") Long routeId

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/controller/RouteController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/controller/RouteController.java
@@ -3,6 +3,7 @@ package org.sopt.pawkey.backendapi.domain.routes.api.controller;
 import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
 
 import org.sopt.pawkey.backendapi.domain.routes.api.dto.RouteRegisterRequest;
+import org.sopt.pawkey.backendapi.domain.routes.api.dto.RouteRegisterResponse;
 import org.sopt.pawkey.backendapi.domain.routes.application.dto.result.RouteRegisterResult;
 import org.sopt.pawkey.backendapi.domain.routes.application.facade.command.RouteRegisterFacade;
 import org.sopt.pawkey.backendapi.global.response.ApiResponse;
@@ -32,7 +33,8 @@ public class RouteController {
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "산책 루트 정보 등록 성공"),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "조회 실패 (U40401 또는 R40401 에러코드 확인)")})
-	public ResponseEntity<ApiResponse<RouteRegisterResult>> registerRoute(@RequestHeader(USER_ID_HEADER) Long userId,
+	public ResponseEntity<ApiResponse<RouteRegisterResponse>> registerRoute(
+		@RequestHeader(USER_ID_HEADER) Long userId,
 		@RequestPart("trackingImage") MultipartFile trackingImage,
 		@Valid @RequestPart("routeRequest") RouteRegisterRequest routeRegisterRequest) {
 
@@ -42,7 +44,6 @@ public class RouteController {
 			trackingImage);
 
 		return ResponseEntity.ok(
-			ApiResponse.success(result));
+			ApiResponse.success(RouteRegisterResponse.from(result)));
 	}
-
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/controller/RouteController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/controller/RouteController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/dto/GetRouteTrackingInfoResponse.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/dto/GetRouteTrackingInfoResponse.java
@@ -1,0 +1,30 @@
+package org.sopt.pawkey.backendapi.domain.routes.api.dto;
+
+import org.sopt.pawkey.backendapi.domain.routes.application.dto.result.GetRouteTrackingInfoResult;
+
+import lombok.Builder;
+
+public record GetRouteTrackingInfoResponse(
+	RouteDto routeDto,
+	String petName
+) {
+	public static GetRouteTrackingInfoResponse from(GetRouteTrackingInfoResult result) {
+		return new GetRouteTrackingInfoResponse(
+			RouteDto.builder()
+				.id(result.routeDto().id())
+				.locationDescription(result.routeDto().locationDescription())
+				.dateDescription(result.routeDto().dateDescription())
+				.build(),
+			result.petName()
+		);
+	}
+
+	@Builder
+	public record RouteDto(
+		Long id,
+		String locationDescription,
+		String dateDescription
+	) {
+
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/dto/RouteRegisterResponse.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/dto/RouteRegisterResponse.java
@@ -2,7 +2,6 @@ package org.sopt.pawkey.backendapi.domain.routes.api.dto;
 
 import org.sopt.pawkey.backendapi.domain.routes.application.dto.result.RouteRegisterResult;
 
-
 public record RouteRegisterResponse(
 	Long routeId
 ) {

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/dto/RouteRegisterResponse.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/dto/RouteRegisterResponse.java
@@ -1,0 +1,13 @@
+package org.sopt.pawkey.backendapi.domain.routes.api.dto;
+
+import org.sopt.pawkey.backendapi.domain.routes.application.dto.result.RouteRegisterResult;
+
+
+public record RouteRegisterResponse(
+	Long routeId
+) {
+	public static RouteRegisterResponse from(RouteRegisterResult result) {
+		return new RouteRegisterResponse(result.routeId());
+	}
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/dto/command/GetRouteTrackingInfoCommand.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/dto/command/GetRouteTrackingInfoCommand.java
@@ -1,0 +1,4 @@
+package org.sopt.pawkey.backendapi.domain.routes.application.dto.command;
+
+public record GetRouteTrackingInfoCommand(Long routeId) {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/dto/result/GetRouteTrackingInfoResult.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/dto/result/GetRouteTrackingInfoResult.java
@@ -1,15 +1,5 @@
 package org.sopt.pawkey.backendapi.domain.routes.application.dto.result;
 
-import java.time.format.DateTimeFormatter;
-import java.util.Locale;
-
-import org.sopt.pawkey.backendapi.domain.pet.infra.persistence.entity.PetEntity;
-import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
-import org.sopt.pawkey.backendapi.domain.routes.exception.RouteBusinessException;
-import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
-import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
-import org.sopt.pawkey.backendapi.global.exception.GlobalErrorCode;
-
 import lombok.Builder;
 
 public record GetRouteTrackingInfoResult(

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/dto/result/GetRouteTrackingInfoResult.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/dto/result/GetRouteTrackingInfoResult.java
@@ -1,0 +1,28 @@
+package org.sopt.pawkey.backendapi.domain.routes.application.dto.result;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+import org.sopt.pawkey.backendapi.domain.pet.infra.persistence.entity.PetEntity;
+import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
+import org.sopt.pawkey.backendapi.domain.routes.exception.RouteBusinessException;
+import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+import org.sopt.pawkey.backendapi.global.exception.GlobalErrorCode;
+
+import lombok.Builder;
+
+public record GetRouteTrackingInfoResult(
+	RouteDto routeDto,
+	String petName
+) {
+	@Builder
+	public record RouteDto(
+		Long id,
+		String locationDescription,
+		String dateDescription
+	) {
+
+	}
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/facade/query/GetRouteTrackingInfoFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/facade/query/GetRouteTrackingInfoFacade.java
@@ -1,5 +1,6 @@
 package org.sopt.pawkey.backendapi.domain.routes.application.facade.query;
 
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
@@ -29,21 +30,14 @@ public class GetRouteTrackingInfoFacade {
 
 	public GetRouteTrackingInfoResult execute(Long userId, GetRouteTrackingInfoCommand getRouteTrackingInfoCommand) {
 		UserEntity user = userService.getByUserId(userId);
-		RouteEntity route = routeService.getRouteById(getRouteTrackingInfoCommand.routeId());
-		if (!route.getUser().equals(user)) {
-			throw new RouteBusinessException(RouteErrorCode.ROUTE_SHOW_FORBIDDEN);
-		}
 
-		String dateDescription = route.getCreatedAt()
-			.format(DateTimeFormatter.ofPattern("yyyy.MM.dd(E) | a hh:mm")
-				.withLocale(Locale.KOREAN));
+		RouteEntity route = routeService.getRouteById(getRouteTrackingInfoCommand.routeId());
+
+		route.validateOwnership(user);
+		String dateDescription = getFormattedDate(route.getCreatedAt());
 		String locationDescription = route.getRegion().getFullRegionName();
 
-		PetEntity pet = user.getPet();
-		if (pet == null) {
-			throw new RouteBusinessException(RouteErrorCode.USER_PET_NOT_REGISTERED);
-		}
-		String petName = pet.getName();
+		PetEntity pet = user.getPetOrThrow();
 
 		return new GetRouteTrackingInfoResult(
 			GetRouteTrackingInfoResult.RouteDto.builder()
@@ -51,7 +45,13 @@ public class GetRouteTrackingInfoFacade {
 				.locationDescription(locationDescription)
 				.dateDescription(dateDescription)
 				.build(),
-			petName
+			pet.getName()
 		);
+	}
+
+	private static String getFormattedDate(LocalDateTime date) {
+		return date
+			.format(DateTimeFormatter.ofPattern("yyyy.MM.dd(E) | a hh:mm")
+				.withLocale(Locale.KOREAN));
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/facade/query/GetRouteTrackingInfoFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/facade/query/GetRouteTrackingInfoFacade.java
@@ -8,12 +8,8 @@ import org.sopt.pawkey.backendapi.domain.pet.infra.persistence.entity.PetEntity;
 import org.sopt.pawkey.backendapi.domain.routes.application.dto.command.GetRouteTrackingInfoCommand;
 import org.sopt.pawkey.backendapi.domain.routes.application.dto.result.GetRouteTrackingInfoResult;
 import org.sopt.pawkey.backendapi.domain.routes.application.service.RouteService;
-import org.sopt.pawkey.backendapi.domain.routes.exception.RouteBusinessException;
-import org.sopt.pawkey.backendapi.domain.routes.exception.RouteErrorCode;
 import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
 import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
-import org.sopt.pawkey.backendapi.domain.user.exception.UserBusinessException;
-import org.sopt.pawkey.backendapi.domain.user.exception.UserErrorCode;
 import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +23,12 @@ public class GetRouteTrackingInfoFacade {
 
 	private final UserService userService;
 	private final RouteService routeService;
+
+	private static String getFormattedDate(LocalDateTime date) {
+		return date
+			.format(DateTimeFormatter.ofPattern("yyyy.MM.dd(E) | a hh:mm")
+				.withLocale(Locale.KOREAN));
+	}
 
 	public GetRouteTrackingInfoResult execute(Long userId, GetRouteTrackingInfoCommand getRouteTrackingInfoCommand) {
 		UserEntity user = userService.getByUserId(userId);
@@ -47,11 +49,5 @@ public class GetRouteTrackingInfoFacade {
 				.build(),
 			pet.getName()
 		);
-	}
-
-	private static String getFormattedDate(LocalDateTime date) {
-		return date
-			.format(DateTimeFormatter.ofPattern("yyyy.MM.dd(E) | a hh:mm")
-				.withLocale(Locale.KOREAN));
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/facade/query/GetRouteTrackingInfoFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/facade/query/GetRouteTrackingInfoFacade.java
@@ -1,0 +1,57 @@
+package org.sopt.pawkey.backendapi.domain.routes.application.facade.query;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+import org.sopt.pawkey.backendapi.domain.pet.infra.persistence.entity.PetEntity;
+import org.sopt.pawkey.backendapi.domain.routes.application.dto.command.GetRouteTrackingInfoCommand;
+import org.sopt.pawkey.backendapi.domain.routes.application.dto.result.GetRouteTrackingInfoResult;
+import org.sopt.pawkey.backendapi.domain.routes.application.service.RouteService;
+import org.sopt.pawkey.backendapi.domain.routes.exception.RouteBusinessException;
+import org.sopt.pawkey.backendapi.domain.routes.exception.RouteErrorCode;
+import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
+import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
+import org.sopt.pawkey.backendapi.domain.user.exception.UserBusinessException;
+import org.sopt.pawkey.backendapi.domain.user.exception.UserErrorCode;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class GetRouteTrackingInfoFacade {
+
+	private final UserService userService;
+	private final RouteService routeService;
+
+	public GetRouteTrackingInfoResult execute(Long userId, GetRouteTrackingInfoCommand getRouteTrackingInfoCommand) {
+		UserEntity user = userService.getByUserId(userId);
+		RouteEntity route = routeService.getRouteById(getRouteTrackingInfoCommand.routeId());
+		if (!route.getUser().equals(user)) {
+			throw new RouteBusinessException(RouteErrorCode.ROUTE_SHOW_FORBIDDEN);
+		}
+
+		String dateDescription = route.getCreatedAt()
+			.format(DateTimeFormatter.ofPattern("yyyy.MM.dd(E) | a hh:mm")
+				.withLocale(Locale.KOREAN));
+		String locationDescription = route.getRegion().getFullRegionName();
+
+		PetEntity pet = user.getPet();
+		if (pet == null) {
+			throw new RouteBusinessException(RouteErrorCode.USER_PET_NOT_REGISTERED);
+		}
+		String petName = pet.getName();
+
+		return new GetRouteTrackingInfoResult(
+			GetRouteTrackingInfoResult.RouteDto.builder()
+				.id(route.getRouteId())
+				.locationDescription(locationDescription)
+				.dateDescription(dateDescription)
+				.build(),
+			petName
+		);
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/exception/RouteErrorCode.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/exception/RouteErrorCode.java
@@ -9,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public enum RouteErrorCode implements ErrorCode {
 
-	ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "R40401", "해당 경로를 찾을 수 없습니다.");
+	ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "R40401", "해당 경로를 찾을 수 없습니다."),
+	USER_PET_NOT_REGISTERED(HttpStatus.NOT_FOUND, "R40402", "유저에게 등록된 반려견이 존재하지 않습니다."),
+	ROUTE_SHOW_FORBIDDEN(HttpStatus.FORBIDDEN, "R40301", "조회할 수 없는 경로입니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/exception/RouteErrorCode.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/exception/RouteErrorCode.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 public enum RouteErrorCode implements ErrorCode {
 
 	ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "R40401", "해당 경로를 찾을 수 없습니다."),
-	USER_PET_NOT_REGISTERED(HttpStatus.NOT_FOUND, "R40402", "유저에게 등록된 반려견이 존재하지 않습니다."),
 	ROUTE_SHOW_FORBIDDEN(HttpStatus.FORBIDDEN, "R40301", "조회할 수 없는 경로입니다.");
 
 	private final HttpStatus status;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/infra/persistence/entity/RouteEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/infra/persistence/entity/RouteEntity.java
@@ -9,6 +9,8 @@ import org.locationtech.jts.geom.LineString;
 import org.sopt.pawkey.backendapi.domain.image.infra.persistence.entity.ImageEntity;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 import org.sopt.pawkey.backendapi.domain.routes.application.dto.command.RouteRegisterCommand;
+import org.sopt.pawkey.backendapi.domain.routes.exception.RouteBusinessException;
+import org.sopt.pawkey.backendapi.domain.routes.exception.RouteErrorCode;
 import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
 
@@ -97,4 +99,9 @@ public class RouteEntity extends BaseEntity {
 		return geometryFactory.createLineString(coords);
 	}
 
+	public void validateOwnership(UserEntity user) {
+		if (!getUser().equals(user)) {
+			throw new RouteBusinessException(RouteErrorCode.ROUTE_SHOW_FORBIDDEN);
+		}
+	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/exception/UserErrorCode.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 public enum UserErrorCode implements ErrorCode {
 
 	USER_DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT, "U40901", "중복된 로그인 아이디입니다."),
-	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U40401", "유저를 찾을 수 없습니다.");
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U40401", "유저를 찾을 수 없습니다."),
+	USER_PET_NOT_REGISTERED(HttpStatus.NOT_FOUND, "U40402", "유저에게 등록된 반려견이 존재하지 않습니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/UserEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/UserEntity.java
@@ -8,6 +8,10 @@ import org.sopt.pawkey.backendapi.domain.pet.infra.persistence.entity.PetEntity;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewEntity;
+import org.sopt.pawkey.backendapi.domain.routes.exception.RouteBusinessException;
+import org.sopt.pawkey.backendapi.domain.routes.exception.RouteErrorCode;
+import org.sopt.pawkey.backendapi.domain.user.exception.UserBusinessException;
+import org.sopt.pawkey.backendapi.domain.user.exception.UserErrorCode;
 import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
 
 import jakarta.persistence.CascadeType;
@@ -69,7 +73,16 @@ public class UserEntity extends BaseEntity {
 		return petEntityList.stream()
 			.findFirst()
 			.orElse(null);
-	} // Optional<PetEntity>을 반환하도록 변경하여 null 처리를 명시적으로 만드는 것을 고려
+	}
+
+	public PetEntity getPetOrThrow() {
+		PetEntity pet = getPet();
+		if (pet == null) {
+			throw new UserBusinessException(UserErrorCode.USER_PET_NOT_REGISTERED);
+		}
+
+		return pet;
+	}
 
 	@Override
 	public boolean equals(Object o) {

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/UserEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/UserEntity.java
@@ -8,8 +8,6 @@ import org.sopt.pawkey.backendapi.domain.pet.infra.persistence.entity.PetEntity;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewEntity;
-import org.sopt.pawkey.backendapi.domain.routes.exception.RouteBusinessException;
-import org.sopt.pawkey.backendapi.domain.routes.exception.RouteErrorCode;
 import org.sopt.pawkey.backendapi.domain.user.exception.UserBusinessException;
 import org.sopt.pawkey.backendapi.domain.user.exception.UserErrorCode;
 import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/UserEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/UserEntity.java
@@ -2,6 +2,7 @@ package org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.sopt.pawkey.backendapi.domain.pet.infra.persistence.entity.PetEntity;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
@@ -70,5 +71,21 @@ public class UserEntity extends BaseEntity {
 			.orElse(null);
 	} // Optional<PetEntity>을 반환하도록 변경하여 null 처리를 명시적으로 만드는 것을 고려
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+
+		UserEntity that = (UserEntity)o;
+
+		return userId != null && userId.equals(that.userId);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(userId);
+	}
 }
 


### PR DESCRIPTION
## 📌 PR 제목
[FEAT] 산책 루트 정보 조회 API

---

## ✨ 요약 설명
게시물 등록 페이지에서 필요한 산책 루트 정보 조회하는 api

---

## 🧾 변경 사항
- 게시물 등록 페이지에서 필요한 산책 루트 정보를 조회하는 API를 구현합니다.
- UserEntity에 equals, hashCode 메서드를 추가했습니다.
- User의 반려견 소유권 검증 책임을 getPetOrThrow 메서드 내부로 이동시켰습니다.
- Route에 대한 User의 소유권 검증 책임을 RouteEntity 내부로 이동시켰습니다.

---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
<img width="734" height="681" alt="image" src="https://github.com/user-attachments/assets/0e5f847f-9694-4502-bb4f-eb728ed526ef" />

- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 파사드에서 dto 조립과정을 거치니까 파사드가 조금 무거워질라그러나 싶기는 한데, 아직 많이 큰 파사드는 아니라서, 일단 그대로 뒀습니다.
    - 책임의 분산에 대해 뭔가 더욱 조언해주실 부분이 있다면 조언해주세용.

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #71 
- Fix #67 