### PR TITLE
[FIX] 산책 게시물 등록 API 루트 이미지 추가 로직 삭제

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/controller/PostController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/controller/PostController.java
@@ -45,10 +45,10 @@ public class PostController {
 		@Parameter(description = "게시물 생성 요청 데이터 (JSON 형식)")
 		PostCreateRequestDto requestDto,
 
-		@RequestPart("image")
-		@Valid @NotNull
-		@Parameter(description = "게시물에 첨부할 대표 이미지 (이미지 파일)")
-		MultipartFile image,
+		// @RequestPart("image")
+		// @Valid @NotNull
+		// @Parameter(description = "게시물에 첨부할 대표 이미지 (이미지 파일)")
+		// MultipartFile image,
 
 		@RequestPart("images")
 		@Valid @NotNull
@@ -56,7 +56,7 @@ public class PostController {
 		List<MultipartFile> images
 
 	) {
-		postFacade.createPost(userId.longValue(), requestDto, image, images);
+		postFacade.createPost(userId.longValue(), requestDto, images);
 		return ResponseEntity.ok(ApiResponse.success(null));
 	}
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/dto/command/PostCreateCommand.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/dto/command/PostCreateCommand.java
@@ -12,7 +12,6 @@ public class PostCreateCommand {
 	private final String description;
 	private final boolean isPublic;
 	private final List<SelectedOptionsForCategory> selectedOptionsForCategories;
-	private final String routeImageUrl;
 	private final List<String> postImageUrlList;
 	private final Long routeId;
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/command/PostFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/command/PostFacade.java
@@ -27,21 +27,10 @@ public class PostFacade {
 	@Transactional
 	public void createPost(Long userId,
 		PostCreateRequestDto requestDto,
-		MultipartFile routeImage,
 		List<MultipartFile> postImages) {
-
 		UserEntity writer = userService.findById(userId);
 		RouteEntity region = routeService.getRouteById(requestDto.getRouteId());
 
-		// final String routeImageUrl = (routeImage != null && !routeImage.isEmpty())
-		// 	? imageStorage.uploadRouteImage(routeImage)
-		// 	: null;
-		//
-		// final List<String> postImageUrlList = (postImages != null && !postImages.isEmpty())
-		// 	? imageStorage.uploadWalkImages(postImages)
-		// 	: Collections.emptyList();
-
-		String routeImageUrl = "routeImageUrl";
 		List<String> postImageUrlList = List.of("postImageUrlList");
 
 		PostCreateCommand command = new PostCreateCommand(
@@ -49,7 +38,6 @@ public class PostFacade {
 			requestDto.getDescription(),
 			requestDto.isPublic(),
 			requestDto.getSelectedOptionsForCategories(),
-			routeImageUrl,
 			postImageUrlList,
 			requestDto.getRouteId()
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/service/PostService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/service/PostService.java
@@ -6,7 +6,6 @@ import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntit
 
 public interface PostService {
 	PostEntity findById(Long postId);
-
 	void createPost(UserEntity writer, PostCreateCommand command);
 
 }


### PR DESCRIPTION
## 📌 PR 제목
[FIX] 산책 게시물 등록 API 루트 이미지 추가 로직 삭제

---

## ✨ 요약 설명
기획 요구사항에 따라, 산책 게시물 등록 API에서 루트 이미지 추가 로직을 삭제했습니다.
(산책 이미지 리스트 추가 로직은 유지)

---

## 🧾 변경 사항
-  이미지 추가 로직 삭제

---

## 📂 PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말

---

## 🔗 관련 이슈


- Close #66 
- Fix #66 