### PR TITLE
[feat] 지역구 영역 수정 API 구현

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/service/RegionService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/service/RegionService.java
@@ -3,5 +3,5 @@ package org.sopt.pawkey.backendapi.domain.region.application.service;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 
 public interface RegionService {
-	RegionEntity getRegionById(Long regionId);
+	RegionEntity getRegionByIdOrThrow(Long regionId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/service/RegionServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/service/RegionServiceImpl.java
@@ -15,7 +15,7 @@ public class RegionServiceImpl implements RegionService {
 	private final RegionRepository regionRepository;
 
 	@Override
-	public RegionEntity getRegionById(Long regionId) {
+	public RegionEntity getRegionByIdOrThrow(Long regionId) {
 
 		return regionRepository.getById(regionId)
 			.orElseThrow(() -> new RegionBusinessException(RegionErrorCode.REGION_NOT_FOUND));

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/exception/RegionErrorCode.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/exception/RegionErrorCode.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 public enum RegionErrorCode implements ErrorCode {
 
 	REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "R40401", "해당 지역을 찾을 수 없습니다."),
-	REGION_TYPE_NOT_DONG(HttpStatus.BAD_REQUEST, "R40401", "소속 지역은 동 단위만 선택 가능합니다.");
+	REGION_TYPE_NOT_DONG(HttpStatus.BAD_REQUEST, "R40001", "소속 지역은 동 단위만 선택 가능합니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/exception/RegionErrorCode.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/exception/RegionErrorCode.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public enum RegionErrorCode implements ErrorCode {
 
-	REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "R40401", "해당 지역을 찾을 수 없습니다.");
+	REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "R40401", "해당 지역을 찾을 수 없습니다."),
+	REGION_TYPE_NOT_DONG(HttpStatus.BAD_REQUEST, "R40401", "소속 지역은 동 단위만 선택 가능합니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/facade/command/RouteRegisterFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/facade/command/RouteRegisterFacade.java
@@ -22,7 +22,7 @@ public class RouteRegisterFacade {
 	private final ImageService imageService;
 
 	public RouteRegisterResult execute(Long userId, RouteRegisterCommand command, MultipartFile trackingImage) {
-		UserEntity user = userService.getByUserId(userId);
+		UserEntity user = userService.findById(userId);
 		ImageEntity imageEntity = imageService.storeRouteImage(trackingImage);
 
 		try {

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
@@ -1,0 +1,44 @@
+package org.sopt.pawkey.backendapi.domain.user.api.controller;
+
+import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
+
+import org.sopt.pawkey.backendapi.domain.user.api.dto.request.UpdateUserRegionRequestDto;
+import org.sopt.pawkey.backendapi.domain.user.api.dto.response.UpdateUserRegionResponseDto;
+import org.sopt.pawkey.backendapi.domain.user.application.facade.command.UpdateUserRegionFacade;
+import org.sopt.pawkey.backendapi.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(API_PREFIX + "/users")
+public class UserController {
+
+	private final UpdateUserRegionFacade updateUserRegionFacade;
+
+	@PatchMapping("/me/regions")
+	@Operation(summary = "유저 소속 지역 수정 성공", description = "유저가 소속된 지역(region)을 수정합니다.", tags = {"Posts"})
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "유저 소속 지역 수정 성공")
+	})
+
+	public ResponseEntity<ApiResponse<Void>> updateRegion(
+		@RequestHeader(USER_ID_HEADER) @NotNull Long userId,
+		@Valid @RequestBody UpdateUserRegionRequestDto updateUserRegionRequestDto
+	) {
+		updateUserRegionFacade.execute(userId, updateUserRegionRequestDto.toCommand());
+
+		return ResponseEntity.ok(
+			ApiResponse.success());
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
@@ -3,7 +3,6 @@ package org.sopt.pawkey.backendapi.domain.user.api.controller;
 import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
 
 import org.sopt.pawkey.backendapi.domain.user.api.dto.request.UpdateUserRegionRequestDto;
-import org.sopt.pawkey.backendapi.domain.user.api.dto.response.UpdateUserRegionResponseDto;
 import org.sopt.pawkey.backendapi.domain.user.application.facade.command.UpdateUserRegionFacade;
 import org.sopt.pawkey.backendapi.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
@@ -26,9 +26,11 @@ public class UserController {
 	private final UpdateUserRegionFacade updateUserRegionFacade;
 
 	@PatchMapping("/me/regions")
-	@Operation(summary = "유저 소속 지역 수정 성공", description = "유저가 소속된 지역(region)을 수정합니다.", tags = {"Posts"})
+	@Operation(summary = "유저 소속 지역 수정 성공", description = "유저가 소속된 지역(region)을 수정합니다.", tags = {"Users"})
 	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "유저 소속 지역 수정 성공")
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "유저 소속 지역 수정 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 요청 (R40001: 지역구분이 동이 아닌 경우)"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 찾을 수 없음(U40401, R40401)")
 	})
 
 	public ResponseEntity<ApiResponse<Void>> updateRegion(

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/request/UpdateUserRegionRequestDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/request/UpdateUserRegionRequestDto.java
@@ -1,0 +1,13 @@
+package org.sopt.pawkey.backendapi.domain.user.api.dto.request;
+
+import org.sopt.pawkey.backendapi.domain.user.application.dto.request.UpdateUserRegionCommand;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateUserRegionRequestDto(
+	@NotNull(message = "지역 아이디는 필수입니다.") Long regionId
+) {
+	public UpdateUserRegionCommand toCommand() {
+		return new UpdateUserRegionCommand(regionId());
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/response/UpdateUserRegionResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/response/UpdateUserRegionResponseDto.java
@@ -1,0 +1,4 @@
+package org.sopt.pawkey.backendapi.domain.user.api.dto.response;
+
+public record UpdateUserRegionResponseDto() {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/dto/request/UpdateUserRegionCommand.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/dto/request/UpdateUserRegionCommand.java
@@ -1,0 +1,6 @@
+package org.sopt.pawkey.backendapi.domain.user.application.dto.request;
+
+public record UpdateUserRegionCommand(
+	Long regionId
+) {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/command/UpdateUserRegionFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/command/UpdateUserRegionFacade.java
@@ -1,9 +1,8 @@
-package org.sopt.pawkey.backendapi.domain.region.application.facade.query;
+package org.sopt.pawkey.backendapi.domain.user.application.facade.command;
 
-import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionCoordinatesCommand;
-import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegionCoordinatesResult;
 import org.sopt.pawkey.backendapi.domain.region.application.service.RegionService;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
+import org.sopt.pawkey.backendapi.domain.user.application.dto.request.UpdateUserRegionCommand;
 import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
 import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.springframework.stereotype.Component;
@@ -13,18 +12,15 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class GetRegionCoordinatesFacade {
+@Transactional
+public class UpdateUserRegionFacade {
 
 	private final RegionService regionService;
 	private final UserService userService;
 
-	public GetRegionCoordinatesResult execute(Long userId,
-		GetRegionCoordinatesCommand getRegionCoordinatesCommand) {
-
+	public void execute(Long userId, UpdateUserRegionCommand command) {
 		UserEntity user = userService.findById(userId);
-		RegionEntity region = regionService.getRegionByIdOrThrow(getRegionCoordinatesCommand.regionId());
-
-		return GetRegionCoordinatesResult.from(region);
+		RegionEntity region = regionService.getRegionByIdOrThrow(command.regionId());
+		userService.updateUserRegion(user, region);
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/command/UpdateUserRegionFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/command/UpdateUserRegionFacade.java
@@ -1,6 +1,9 @@
 package org.sopt.pawkey.backendapi.domain.user.application.facade.command;
 
 import org.sopt.pawkey.backendapi.domain.region.application.service.RegionService;
+import org.sopt.pawkey.backendapi.domain.region.domain.model.RegionType;
+import org.sopt.pawkey.backendapi.domain.region.exception.RegionBusinessException;
+import org.sopt.pawkey.backendapi.domain.region.exception.RegionErrorCode;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 import org.sopt.pawkey.backendapi.domain.user.application.dto.request.UpdateUserRegionCommand;
 import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
@@ -21,6 +24,11 @@ public class UpdateUserRegionFacade {
 	public void execute(Long userId, UpdateUserRegionCommand command) {
 		UserEntity user = userService.findById(userId);
 		RegionEntity region = regionService.getRegionByIdOrThrow(command.regionId());
+
+		if (region.getRegionType() != RegionType.DONG) {
+			throw new RegionBusinessException(RegionErrorCode.REGION_TYPE_NOT_DONG);
+		}
+
 		userService.updateUserRegion(user, region);
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserService.java
@@ -1,9 +1,10 @@
 package org.sopt.pawkey.backendapi.domain.user.application.service;
 
+import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 
 public interface UserService {
-	UserEntity getByUserId(Long userId);
-
 	UserEntity findById(Long userId);
+
+	void updateUserRegion(UserEntity user, RegionEntity region);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package org.sopt.pawkey.backendapi.domain.user.application.service;
 
+import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 import org.sopt.pawkey.backendapi.domain.user.domain.repository.UserQueryRepository;
 import org.sopt.pawkey.backendapi.domain.user.domain.repository.UserRepository;
 import org.sopt.pawkey.backendapi.domain.user.exception.UserBusinessException;
@@ -16,15 +17,14 @@ public class UserServiceImpl implements UserService {
 	private final UserQueryRepository userQueryRepository;
 	private final UserRepository userRepository;
 
-	@Override
-	public UserEntity getByUserId(Long userId) {
-		return userQueryRepository.getUserByUserId(userId)
-			.orElseThrow(() -> new UserBusinessException(UserErrorCode.USER_NOT_FOUND));
-	}
-
 	public UserEntity findById(final Long id) {
 		return userRepository.findById(id)
 			.orElseThrow(() -> new UserBusinessException(UserErrorCode.USER_NOT_FOUND));
+	}
+
+	@Override
+	public void updateUserRegion(UserEntity user, RegionEntity region) {
+		user.updateRegion(region);
 	}
 }
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/UserEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/UserEntity.java
@@ -70,5 +70,8 @@ public class UserEntity extends BaseEntity {
 			.orElse(null);
 	} // Optional<PetEntity>을 반환하도록 변경하여 null 처리를 명시적으로 만드는 것을 고려
 
+	public void updateRegion(RegionEntity region) {
+		this.region = region;
+	}
 }
 

--- a/src/main/java/org/sopt/pawkey/backendapi/global/response/ApiResponse.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/response/ApiResponse.java
@@ -1,7 +1,5 @@
 package org.sopt.pawkey.backendapi.global.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/org/sopt/pawkey/backendapi/global/response/ApiResponse.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/response/ApiResponse.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
 
 	/**


### PR DESCRIPTION
## 📌 PR 제목
[feat] 지역구 영역 수정 API 구현

---

## ✨ 요약 설명
유저가 소속된 지역정보를 수정하는 로직을 추가함.

---

## 🧾 변경 사항

- 유저가 속한 지역을 수정하는 기능을 구현합니다.
- 유저 ID를 받아 유저 정보를 조회합니다.
- 지역 ID를 받아 지역 정보를 조회합니다.
- 유저 정보를 업데이트합니다.
- 기존의 `getByUserId` 메소드를 `findById`로 변경하고, 존재하지 않는 Region에 대한 예외 처리를 추가합니다.
- 유저의 소속 지역을 업데이트할 때 선택한 지역이 '동' 단위인지 검증하는 로직을 추가합니다.
- 이를 통해 유저가 잘못된 형식의 지역을 선택하는 것을 방지하고, 데이터의 정확성을 유지합니다.
- RegionErrorCode에 새로운 에러 코드(REGION_TYPE_NOT_DONG)를 추가하여 '동' 단위가 아닌 지역을 선택했을 경우에 대한 예외 처리를 명확히 합니다.

---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
<img width="586" height="553" alt="image" src="https://github.com/user-attachments/assets/0d886d3c-699a-41b9-bcc9-895e204e30d6" />
- [x] 로컬 실행 결과 화면 캡처 포함
<img width="1129" height="276" alt="image" src="https://github.com/user-attachments/assets/9e57760e-f878-40f1-810f-7f3467b630ff" />


---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 업데이트 로직을 변경감지를 통해서 구현했습니다.
- 서비스로직까지 끌고 가지 않고, 파사드에서도 충분히 가능할 것 같았지만, 추후 변경 로직이 수정될 수 있다고 생각하여 userService 내부로 로직을 넣었습니다.

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #82 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 자신의 소속 지역(동 단위)을 업데이트할 수 있는 PATCH API 엔드포인트가 추가되었습니다.
  * 지역 변경 요청 시 유효성 검사 및 오류 코드가 제공됩니다.

* **버그 수정**
  * 지역 조회 시 존재하지 않는 경우 명확한 예외가 발생하도록 개선되었습니다.

* **기타**
  * API 응답에서 null 값 포함 정책이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->