### PR TITLE
[feat] 지역 조회 시 이전 지역 정보 추가

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/controller/PostController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/controller/PostController.java
@@ -4,8 +4,6 @@ import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
 
 import java.util.List;
 
-import org.sopt.pawkey.backendapi.domain.category.api.dto.response.CategoryListResponseDto;
-import org.sopt.pawkey.backendapi.domain.category.application.dto.result.CategoryResult;
 import org.sopt.pawkey.backendapi.domain.post.api.dto.request.PostCreateRequestDto;
 import org.sopt.pawkey.backendapi.domain.post.api.dto.response.PostRegisterResponseDto;
 import org.sopt.pawkey.backendapi.domain.post.api.dto.response.PostResponseDto;
@@ -61,7 +59,6 @@ public class PostController {
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 
-
 	@Operation(summary = "게시물 상세 조회", description = "산책 게시물의 상세정보를 조회합니다.", tags = {"Posts"})
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "게시물 상세 조회 성공"),
@@ -72,9 +69,8 @@ public class PostController {
 		@RequestHeader(USER_ID_HEADER) @NotNull Integer userId,
 		@PathVariable("postId") Long postId
 	) {
-		PostResponseDto response = postQueryFacade.getPostDetail(postId,userId.longValue());
+		PostResponseDto response = postQueryFacade.getPostDetail(postId, userId.longValue());
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response));
 	}
-
 
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/dto/response/PostResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/dto/response/PostResponseDto.java
@@ -13,13 +13,12 @@ public record PostResponseDto(
 	String content,
 	boolean isLike,
 	AuthorDto authorInfo,
-	CategoryTagsDto  categoryTags,
+	CategoryTagsDto categoryTags,
 	String regionName,
 	LocalDateTime createdAt,
 	String routeMapImageUrl,
 	List<String> walkingImageUrls
 ) {
-
 
 	public static PostResponseDto of(
 		Long postId,
@@ -40,7 +39,7 @@ public record PostResponseDto(
 		);
 	}
 
-	public static PostResponseDto from(GetPostResult postResult){
+	public static PostResponseDto from(GetPostResult postResult) {
 		return new PostResponseDto(
 			postResult.postId(),
 			postResult.routeId(),
@@ -56,11 +55,9 @@ public record PostResponseDto(
 		);
 	}
 
-
 	public record CategoryTagsDto(
 		List<String> categoryOptionSummary
-	) {}
-
-
+	) {
+	}
 
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/command/PostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/command/PostQueryFacade.java
@@ -2,16 +2,12 @@ package org.sopt.pawkey.backendapi.domain.post.application.facade.command;
 
 import java.util.List;
 
-import org.sopt.pawkey.backendapi.domain.image.application.service.command.ImageService;
 import org.sopt.pawkey.backendapi.domain.image.domain.model.ImageType;
-import org.sopt.pawkey.backendapi.domain.image.infra.persistence.entity.ImageEntity;
 import org.sopt.pawkey.backendapi.domain.post.api.dto.response.PostResponseDto;
 import org.sopt.pawkey.backendapi.domain.post.application.service.PostQueryService;
 import org.sopt.pawkey.backendapi.domain.post.application.service.PostService;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
-import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostImageEntity;
 import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
-import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,14 +22,15 @@ public class PostQueryFacade {
 	private final PostService postService;
 	private final UserService userService;
 
-	public PostResponseDto getPostDetail(Long postId, Long userId){
+	public PostResponseDto getPostDetail(Long postId, Long userId) {
 
 		PostEntity post = postService.findById(postId);
 
 		boolean isLiked = post.getPostLikeEntityList().stream()
 			.anyMatch(like -> like.getUser().getUserId().equals(userId));
 
-		String routeMapImageUrl = post.getRoute().getTrackingImage() != null ? post.getRoute().getTrackingImage().getImageUrl():null;
+		String routeMapImageUrl =
+			post.getRoute().getTrackingImage() != null ? post.getRoute().getTrackingImage().getImageUrl() : null;
 
 		List<String> walkingImages = post.getPostImages().stream()
 			.filter(img -> img.getImageType() == ImageType.WALK_POST)

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/service/PostQueryServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/service/PostQueryServiceImpl.java
@@ -11,9 +11,10 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class PostQueryServiceImpl implements PostQueryService{
+public class PostQueryServiceImpl implements PostQueryService {
 
-	public PostResponseDto getPostDetail(PostEntity post, boolean isLiked, String routeMapImage, List<String> walkingImages) {
+	public PostResponseDto getPostDetail(PostEntity post, boolean isLiked, String routeMapImage,
+		List<String> walkingImages) {
 
 		//작성자
 		AuthorDto authorDto = new AuthorDto(

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/dto/GetRegionCoordinatesResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/dto/GetRegionCoordinatesResponseDto.java
@@ -9,10 +9,12 @@ import lombok.Builder;
 @Builder
 public record GetRegionCoordinatesResponseDto(
 	String regionName,
+	String preRegionName,
 	Map<String, Object> geometryDto
 ) {
 	public static GetRegionCoordinatesResponseDto from(GetRegionCoordinatesResult result) {
 		return GetRegionCoordinatesResponseDto.builder()
+			.preRegionName(result.preRegionName())
 			.regionName(result.regionName())
 			.geometryDto(result.geometryDto())
 			.build();

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/result/GetRegionCoordinatesResult.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/result/GetRegionCoordinatesResult.java
@@ -9,11 +9,13 @@ import lombok.Builder;
 @Builder
 public record GetRegionCoordinatesResult(
 	String regionName,
+	String preRegionName,
 	Map<String, Object> geometryDto
 ) {
-	public static GetRegionCoordinatesResult from(RegionEntity region) {
+	public static GetRegionCoordinatesResult from(String preRegionName, RegionEntity region) {
 
 		return GetRegionCoordinatesResult.builder()
+			.preRegionName(preRegionName)
 			.regionName(region.getFullRegionName())
 			.geometryDto(region.getGeoJson())
 			.build();

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/facade/query/GetRegionCoordinatesFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/facade/query/GetRegionCoordinatesFacade.java
@@ -25,6 +25,6 @@ public class GetRegionCoordinatesFacade {
 		UserEntity user = userService.findById(userId);
 		RegionEntity region = regionService.getRegionByIdOrThrow(getRegionCoordinatesCommand.regionId());
 
-		return GetRegionCoordinatesResult.from(region);
+		return GetRegionCoordinatesResult.from(user.getRegion().getFullRegionName(), region);
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/AuthorDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/AuthorDto.java
@@ -5,4 +5,5 @@ public record AuthorDto(
 	Long petId,
 	String petName,
 	String petProfileImage
-) {}
+) {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
@@ -35,7 +35,6 @@ public class UserLikedPostQueryFacade {
 
 				String imageurldummy = "imageurl";
 
-
 				var writer = post.getUser();
 				Long writerId = writer.getUserId();
 				String writerPetName = writer.getPet() != null ? writer.getPet().getName() : null;

--- a/src/main/java/org/sopt/pawkey/backendapi/global/infra/filter/RequestLoggingFilter.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/infra/filter/RequestLoggingFilter.java
@@ -1,5 +1,15 @@
 package org.sopt.pawkey.backendapi.global.infra.filter;
 
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -7,15 +17,6 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.stereotype.Component;
-
-import java.io.IOException;
-import java.util.Enumeration;
-import java.util.UUID;
 
 @Component
 @ConditionalOnProperty(
@@ -31,8 +32,8 @@ public class RequestLoggingFilter implements Filter {
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
 		throws IOException, ServletException {
 
-		HttpServletRequest httpRequest = (HttpServletRequest) request;
-		HttpServletResponse httpResponse = (HttpServletResponse) response;
+		HttpServletRequest httpRequest = (HttpServletRequest)request;
+		HttpServletResponse httpResponse = (HttpServletResponse)response;
 
 		String uri = httpRequest.getRequestURI();
 		// api/v1 만 로깅


### PR DESCRIPTION
## 📌 PR 제목
ex) [feat] 회원가입 API 구현  
ex) [bug] JWT 검증 오류 수정  
ex) [refactor] 응답 포맷 통일

---

## ✨ 요약 설명
- 지역 조회 시 이전 지역 정보 추가

---

## 🧾 변경 사항
- 지역 좌표 조회 시 사용자의 이전 지역 정보를 함께 반환하도록 기능을 개선합니다.

---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
<img width="949" height="749" alt="image" src="https://github.com/user-attachments/assets/9493893a-9be6-4245-bc04-727b5cece448" />
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말


---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #93 