### PR TITLE
[feat] 게시물 작성을 위한 루트 정보 api 에서 descriptionTags 추가

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/dto/GetRouteInfoForPostResponse.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/dto/GetRouteInfoForPostResponse.java
@@ -1,5 +1,7 @@
 package org.sopt.pawkey.backendapi.domain.routes.api.dto;
 
+import java.util.List;
+
 import org.sopt.pawkey.backendapi.domain.routes.application.dto.result.GetRouteInfoForPostResult;
 
 import lombok.Builder;
@@ -14,6 +16,7 @@ public record GetRouteInfoForPostResponse(
 				.id(result.routeDto().id())
 				.locationDescription(result.routeDto().locationDescription())
 				.dateDescription(result.routeDto().dateDescription())
+				.descriptionTags(result.routeDto().descriptionTags())
 				.build(),
 			result.petName()
 		);
@@ -23,7 +26,8 @@ public record GetRouteInfoForPostResponse(
 	public record RouteDto(
 		Long id,
 		String locationDescription,
-		String dateDescription
+		String dateDescription,
+		List<String> descriptionTags
 	) {
 
 	}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/dto/result/GetRouteInfoForPostResult.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/dto/result/GetRouteInfoForPostResult.java
@@ -1,5 +1,7 @@
 package org.sopt.pawkey.backendapi.domain.routes.application.dto.result;
 
+import java.util.List;
+
 import lombok.Builder;
 
 public record GetRouteInfoForPostResult(
@@ -10,7 +12,8 @@ public record GetRouteInfoForPostResult(
 	public record RouteDto(
 		Long id,
 		String locationDescription,
-		String dateDescription
+		String dateDescription,
+		List<String> descriptionTags
 	) {
 
 	}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/facade/query/GetRouteInfoForPostFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/facade/query/GetRouteInfoForPostFacade.java
@@ -2,6 +2,7 @@ package org.sopt.pawkey.backendapi.domain.routes.application.facade.query;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Locale;
 
 import org.sopt.pawkey.backendapi.domain.pet.infra.persistence.entity.PetEntity;
@@ -24,12 +25,6 @@ public class GetRouteInfoForPostFacade {
 	private final UserService userService;
 	private final RouteService routeService;
 
-	private static String getFormattedDate(LocalDateTime date) {
-		return date
-			.format(DateTimeFormatter.ofPattern("yyyy.MM.dd(E) | a hh:mm")
-				.withLocale(Locale.KOREAN));
-	}
-
 	public GetRouteInfoForPostResult execute(Long userId, GetRouteInfoForPostCommand getRouteInfoForPostCommand) {
 		UserEntity user = userService.findById(userId);
 
@@ -41,13 +36,33 @@ public class GetRouteInfoForPostFacade {
 
 		PetEntity pet = user.getPetOrThrow();
 
+		List<String> descriptionTags = List.of(formatDistance(route.getDistance()),
+			formatDuration(route.getDuration()));
+
 		return new GetRouteInfoForPostResult(
 			GetRouteInfoForPostResult.RouteDto.builder()
 				.id(route.getRouteId())
 				.locationDescription(locationDescription)
 				.dateDescription(dateDescription)
+				.descriptionTags(descriptionTags)
 				.build(),
 			pet.getName()
 		);
+	}
+
+	private static String getFormattedDate(LocalDateTime date) {
+		return date
+			.format(DateTimeFormatter.ofPattern("yyyy.MM.dd(E) | a hh:mm")
+				.withLocale(Locale.KOREAN));
+	}
+
+	private static String formatDistance(int meters) {
+		double km = meters / 1000.0;
+		return String.format("%.1fkm", km);
+	}
+
+	private static String formatDuration(int seconds) {
+		int minutes = seconds / 60;
+		return minutes + "분";
 	}
 }


### PR DESCRIPTION
## 📌 PR 제목
게시물 작성을 위한 루트 정보 api 에서 descriptionTags 추가

---

## ✨ 요약 설명
- 게시물 작성을 위한 루트 정보 api 에서 descriptionTags 추가

---

## 🧾 변경 사항
- api, application dto 수정

---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
<img width="735" height="742" alt="image" src="https://github.com/user-attachments/assets/1abd02b5-0aa4-46bf-a468-3c986c816095" />
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #96 