### PR TITLE
[FEATURE] 리뷰 카테고리 선택 API

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/dto/request/PostCreateRequestDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/dto/request/PostCreateRequestDto.java
@@ -42,3 +42,5 @@ public class PostCreateRequestDto {
 			.build();
 	}
 }
+
+

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/service/PostService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/service/PostService.java
@@ -10,7 +10,6 @@ import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntit
 
 public interface PostService {
 	PostEntity findById(Long postId);
-
 	PostEntity savePost(UserEntity writer,
 		PostRegisterCommand command,
 		RouteEntity route,

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/domain/repository/CategoryOptionRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/domain/repository/CategoryOptionRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.pawkey.backendapi.domain.category.domain.repository;
+
+import java.util.Optional;
+
+import org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity.CategoryOptionEntity;
+
+public interface CategoryOptionRepository {
+
+	Optional<CategoryOptionEntity> findById(Long optionId);
+
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/exception/CategoryBusinessException.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/exception/CategoryBusinessException.java
@@ -1,7 +1,10 @@
 package org.sopt.pawkey.backendapi.domain.category.exception;
 
-public class CategoryBusinessException extends RuntimeException {
-	public CategoryBusinessException(String message) {
-		super(message);
+import org.sopt.pawkey.backendapi.global.exception.BusinessException;
+import org.sopt.pawkey.backendapi.global.exception.ErrorCode;
+
+public class CategoryBusinessException extends BusinessException {
+	public CategoryBusinessException(ErrorCode errorCode) {
+		super(errorCode);
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/exception/CategoryErrorCode.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/exception/CategoryErrorCode.java
@@ -1,4 +1,33 @@
 package org.sopt.pawkey.backendapi.domain.category.exception;
 
-public enum CategoryErrorCode {
+import org.sopt.pawkey.backendapi.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public enum CategoryErrorCode implements ErrorCode {
+
+	CATEGORY_ERROR_CODE(HttpStatus.BAD_REQUEST,"R40001","잘못된 카테고리 요청입니다.");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+
+	@Override
+	public String getCode() {
+		return code;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return status;
+	}
+
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/repository/CategoryOptionRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/repository/CategoryOptionRepositoryImpl.java
@@ -1,0 +1,20 @@
+package org.sopt.pawkey.backendapi.domain.category.infra.persistence.repository;
+
+import java.util.Optional;
+
+import org.sopt.pawkey.backendapi.domain.category.domain.repository.CategoryOptionRepository;
+import org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity.CategoryOptionEntity;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CategoryOptionRepositoryImpl implements CategoryOptionRepository {
+	private final SpringDataCategoryOptionRepository jpaRepository;
+
+	@Override
+	public Optional<CategoryOptionEntity> findById(Long optionId) {
+		return jpaRepository.findById(optionId);
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/repository/SpringDataCategoryOptionRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/repository/SpringDataCategoryOptionRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.pawkey.backendapi.domain.category.infra.persistence.repository;
+
+import org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity.CategoryOptionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataCategoryOptionRepository extends JpaRepository<CategoryOptionEntity,Long> {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/service/RegionServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/service/RegionServiceImpl.java
@@ -21,3 +21,4 @@ public class RegionServiceImpl implements RegionService {
 			.orElseThrow(() -> new RegionBusinessException(RegionErrorCode.REGION_NOT_FOUND));
 	}
 }
+

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/api/controller/ReviewController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/api/controller/ReviewController.java
@@ -1,0 +1,60 @@
+package org.sopt.pawkey.backendapi.domain.review.api.controller;
+
+import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.post.api.dto.request.PostCreateRequestDto;
+import org.sopt.pawkey.backendapi.domain.post.api.dto.response.PostRegisterResponseDto;
+import org.sopt.pawkey.backendapi.domain.post.application.dto.command.PostRegisterCommand;
+import org.sopt.pawkey.backendapi.domain.review.api.dto.request.ReviewCreateRequestDto;
+import org.sopt.pawkey.backendapi.domain.review.application.dto.command.ReviewRegisterCommand;
+import org.sopt.pawkey.backendapi.domain.review.application.facade.ReviewRegisterFacade;
+import org.sopt.pawkey.backendapi.global.response.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(API_PREFIX + "/reviews")
+public class ReviewController {
+
+	private final ReviewRegisterFacade reviewRegisterFacade;
+
+
+	@Operation(summary = "리뷰 카테고리 등록", description = "공유된 루트로 산책 완료 후, 리뷰 카테고리를 등록합니다.", tags = {"Reviews"})
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "리뷰 등록 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(mediaType = "application/json")),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json"))})
+	@PostMapping("")
+	public ResponseEntity<ApiResponse<Void>> createPost(
+		@RequestHeader(USER_ID_HEADER) @NotNull Long userId,
+		@RequestBody @Valid @NotNull ReviewCreateRequestDto requestDto
+	) {
+		ReviewRegisterCommand command = requestDto.toCommand();
+
+		reviewRegisterFacade.execute(userId,command);
+
+		return ResponseEntity.ok(ApiResponse.success(null));
+	}
+
+
+
+
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/api/dto/request/ReviewCreateRequestDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/api/dto/request/ReviewCreateRequestDto.java
@@ -1,0 +1,30 @@
+package org.sopt.pawkey.backendapi.domain.review.api.dto.request;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.review.application.dto.selectedReviewSet;
+import org.sopt.pawkey.backendapi.domain.review.application.dto.command.ReviewRegisterCommand;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+
+public class ReviewCreateRequestDto{
+	@NotNull(message = "루트 ID는 필수입니다.")
+	private final Long routeId;
+
+	@NotNull(message = "리뷰 카테고리 선택은 비어 있을 수 없습니다.")
+	private final List<@Valid selectedReviewSet> selectedReviewSetList;
+
+	public ReviewRegisterCommand toCommand(){
+		return ReviewRegisterCommand.builder()
+			.routeId(this.routeId)
+			.selectedReviewSetList(this.selectedReviewSetList)
+			.build();
+	}
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/dto/command/ReviewRegisterCommand.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/dto/command/ReviewRegisterCommand.java
@@ -1,0 +1,14 @@
+package org.sopt.pawkey.backendapi.domain.review.application.dto.command;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.review.application.dto.selectedReviewSet;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewRegisterCommand(
+	Long routeId,
+	List<selectedReviewSet> selectedReviewSetList) {
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/dto/selectedReviewSet.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/dto/selectedReviewSet.java
@@ -1,0 +1,12 @@
+package org.sopt.pawkey.backendapi.domain.review.application.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+
+
+public record selectedReviewSet(
+	Long reviewCategoryId,
+	List<Long> selectedReviewOptionIds
+) {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/facade/ReviewRegisterFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/facade/ReviewRegisterFacade.java
@@ -1,0 +1,35 @@
+package org.sopt.pawkey.backendapi.domain.review.application.facade;
+
+import org.sopt.pawkey.backendapi.domain.review.application.dto.command.ReviewRegisterCommand;
+import org.sopt.pawkey.backendapi.domain.review.application.service.ReviewService;
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewEntity;
+import org.sopt.pawkey.backendapi.domain.routes.application.service.RouteService;
+import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
+import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class ReviewRegisterFacade {
+
+	private final ReviewService reviewService;
+	private final UserService userService;
+	private final RouteService routeService;
+
+	public void execute(Long userId,
+		ReviewRegisterCommand command) {
+
+		UserEntity user = userService.findById(userId);
+		RouteEntity route = routeService.getRouteById(command.routeId());
+
+		ReviewEntity review = reviewService.saveReview(command,user,route);
+
+
+
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/service/ReviewService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/service/ReviewService.java
@@ -1,0 +1,14 @@
+package org.sopt.pawkey.backendapi.domain.review.application.service;
+
+import org.sopt.pawkey.backendapi.domain.review.application.dto.command.ReviewRegisterCommand;
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewEntity;
+import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+
+public interface ReviewService {
+
+
+	ReviewEntity saveReview(ReviewRegisterCommand command,UserEntity user, RouteEntity route);
+
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/service/ReviewServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/service/ReviewServiceImpl.java
@@ -1,0 +1,65 @@
+package org.sopt.pawkey.backendapi.domain.review.application.service;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.category.domain.repository.CategoryOptionRepository;
+import org.sopt.pawkey.backendapi.domain.category.domain.repository.CategoryRepository;
+import org.sopt.pawkey.backendapi.domain.category.exception.CategoryBusinessException;
+import org.sopt.pawkey.backendapi.domain.category.exception.CategoryErrorCode;
+import org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity.CategoryOptionEntity;
+import org.sopt.pawkey.backendapi.domain.post.domain.repository.PostRepository;
+import org.sopt.pawkey.backendapi.domain.review.application.dto.command.ReviewRegisterCommand;
+import org.sopt.pawkey.backendapi.domain.review.domain.repository.ReviewRepository;
+import org.sopt.pawkey.backendapi.domain.review.domain.repository.ReviewSelectedCategoryOptionRepository;
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewEntity;
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewSelectedCategoryOptionEntity;
+import org.sopt.pawkey.backendapi.domain.routes.domain.repository.RouteRepository;
+import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
+import org.sopt.pawkey.backendapi.domain.user.domain.repository.UserRepository;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewServiceImpl implements ReviewService{
+	private final PostRepository postRepository;
+	private final RouteRepository routeRepository;
+	private final UserRepository userRepository;
+	private final ReviewRepository reviewRepository;
+	private final CategoryRepository categoryRepository;
+	private  final CategoryOptionRepository categoryOptionRepository;
+	private final ReviewSelectedCategoryOptionRepository reviewSelectedCategoryOptionRepository;
+
+
+	@Override
+	public ReviewEntity saveReview(ReviewRegisterCommand command, UserEntity user, RouteEntity route) {
+		ReviewEntity review = ReviewEntity.builder()
+			.user(user)
+			.route(route)
+			.build();
+
+		reviewRepository.save(review);
+
+		List<ReviewSelectedCategoryOptionEntity> selectedReviewOptionsForCategory = command.selectedReviewSetList().stream()
+			.flatMap(selectedReviewSet  -> selectedReviewSet.selectedReviewOptionIds().stream()
+				.map(optionId -> {
+					CategoryOptionEntity option = categoryOptionRepository.findById(optionId)
+						.orElseThrow(()-> new CategoryBusinessException(CategoryErrorCode.CATEGORY_ERROR_CODE));
+
+					return ReviewSelectedCategoryOptionEntity.builder()
+						.review(review)
+						.categoryOption(option)
+						.build();
+				})
+			)
+			.toList();
+
+
+		reviewSelectedCategoryOptionRepository.saveAll(selectedReviewOptionsForCategory);
+		return review;
+
+	}
+}
+

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/domain/repository/ReviewRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.pawkey.backendapi.domain.review.domain.repository;
+
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewEntity;
+
+public interface ReviewRepository {
+
+	void save(ReviewEntity review);
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/domain/repository/ReviewSelectedCategoryOptionRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/domain/repository/ReviewSelectedCategoryOptionRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.pawkey.backendapi.domain.review.domain.repository;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewSelectedCategoryOptionEntity;
+
+public interface ReviewSelectedCategoryOptionRepository {
+
+	void saveAll(List<ReviewSelectedCategoryOptionEntity> selectedCategoryOptionEntityList);
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/exception/ReviewErrorCode.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/exception/ReviewErrorCode.java
@@ -1,0 +1,2 @@
+package org.sopt.pawkey.backendapi.domain.review.exception;
+

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/exception/ReviewException.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/exception/ReviewException.java
@@ -1,0 +1,7 @@
+package org.sopt.pawkey.backendapi.domain.review.exception;
+
+public class ReviewException extends RuntimeException {
+	public ReviewException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/ReviewRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/ReviewRepositoryImpl.java
@@ -1,0 +1,19 @@
+package org.sopt.pawkey.backendapi.domain.review.infra.persistence;
+
+import org.sopt.pawkey.backendapi.domain.review.domain.repository.ReviewRepository;
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewEntity;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewRepository {
+
+	private final SpringDataReviewRepository jpaRepository;
+
+	@Override
+	public void save(ReviewEntity review) {
+		jpaRepository.save(review);
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/ReviewSelectedCategoryOptionRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/ReviewSelectedCategoryOptionRepositoryImpl.java
@@ -1,0 +1,22 @@
+package org.sopt.pawkey.backendapi.domain.review.infra.persistence;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.review.domain.repository.ReviewSelectedCategoryOptionRepository;
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewSelectedCategoryOptionEntity;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewSelectedCategoryOptionRepositoryImpl implements ReviewSelectedCategoryOptionRepository {
+
+
+	private final SpringDataReviewSelectedCategoryOptionRepository jpaRepository;
+
+	@Override
+	public void saveAll(List<ReviewSelectedCategoryOptionEntity> selectedCategoryOptionEntityList) {
+		jpaRepository.saveAll(selectedCategoryOptionEntityList);
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/SpringDataReviewRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/SpringDataReviewRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.pawkey.backendapi.domain.review.infra.persistence;
+
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataReviewRepository extends JpaRepository<ReviewEntity,Long> {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/SpringDataReviewSelectedCategoryOptionRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/SpringDataReviewSelectedCategoryOptionRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.pawkey.backendapi.domain.review.infra.persistence;
+
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewSelectedCategoryOptionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataReviewSelectedCategoryOptionRepository extends JpaRepository<ReviewSelectedCategoryOptionEntity,Long> {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/entity/ReviewEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/entity/ReviewEntity.java
@@ -20,6 +20,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,6 +29,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class ReviewEntity extends BaseEntity {
 
 	@Id

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/entity/ReviewSelectedCategoryOptionEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/entity/ReviewSelectedCategoryOptionEntity.java
@@ -14,6 +14,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,6 +23,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class ReviewSelectedCategoryOptionEntity extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/dto/request/CreateUserCommand.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/dto/request/CreateUserCommand.java
@@ -13,5 +13,4 @@ public record CreateUserCommand(
 		Long regionId) {
 		return new CreateUserCommand(loginId, password, name, gender, age, regionId);
 	}
-
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserService.java
@@ -12,3 +12,4 @@ public interface UserService {
 	void updateUserRegion(UserEntity user, RegionEntity region);
 
 }
+


### PR DESCRIPTION
## 📌 PR 제목
[FEATURE] 리뷰 카테고리 선택 API
---

## ✨ 요약 설명
- 사용자가 특정 산책 루트에 대해 간단한 리뷰(카테고리 + 옵션 선택)를 남길 수 있도록 하는 기능을 추가했습니다.
- 게시물 등록과는 별도로, 루트별 후기를 선택형으로 남길 수 있는 API입니다

---

## 🧾 변경 사항
- 리뷰 등록 API (POST /api/v1/reviews) 추가

- 카테고리 ID와 옵션 ID 리스트를 받는 요청 DTO 및 커맨드 객체 정의

- 유효성 검증, 중복 등록 방지 로직 포함

- 리뷰와 선택된 옵션 간 다대다 관계 처리

- 테스트용 Postman 호출 완료 (200 OK 응답 확인)

---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [x] 로컬 실행 결과 화면 캡처 포함
<img width="850" height="448" alt="image" src="https://github.com/user-attachments/assets/3df86cd7-af49-4cca-b94a-211fbb220773" />

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 추후 리뷰 등록 시 캐싱 테이블(post_category_option_top3) 갱신 로직이 추가될 예정입니다.
- 로직 흐름 및 command → entity 변환 구조에 대해 개선할 부분 있다면 피드백 부탁드려요
- 현재는 등록 시점 기준 단순 저장 로직만 포함되어 있습니다.

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #95 
- Fix #95 