### PR TITLE
[feat] 리뷰 top3조회 api 추가

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/controller/PostController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/controller/PostController.java
@@ -11,6 +11,7 @@ import org.sopt.pawkey.backendapi.domain.post.application.dto.command.PostRegist
 import org.sopt.pawkey.backendapi.domain.post.application.facade.command.PostFacade;
 import org.sopt.pawkey.backendapi.domain.post.application.facade.command.PostQueryFacade;
 import org.sopt.pawkey.backendapi.domain.post.application.facade.command.PostRegisterFacade;
+import org.sopt.pawkey.backendapi.domain.review.api.dto.response.ReviewResponseDto;
 import org.sopt.pawkey.backendapi.global.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -70,6 +71,20 @@ public class PostController {
 		@PathVariable("postId") Long postId
 	) {
 		PostResponseDto response = postQueryFacade.getPostDetail(postId, userId.longValue());
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response));
+	}
+
+	@Operation(summary = "리뷰 TOP3 조회  api", description = "리뷰 TOP3 를 반환합니다. 조회  api.", tags = {"Posts"})
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "리뷰 조회 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(mediaType = "application/json")),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json"))})
+	@GetMapping("/{routeId}/reviews/top")
+	public ResponseEntity<ApiResponse<ReviewResponseDto>> getTopReviewsForPost(
+		@RequestHeader(USER_ID_HEADER) @NotNull Integer userId,
+		@PathVariable("routeId") Long routeId
+	) {
+		ReviewResponseDto response = ReviewResponseDto.createMock();
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response));
 	}
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/command/PostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/command/PostQueryFacade.java
@@ -7,6 +7,7 @@ import org.sopt.pawkey.backendapi.domain.post.api.dto.response.PostResponseDto;
 import org.sopt.pawkey.backendapi.domain.post.application.service.PostQueryService;
 import org.sopt.pawkey.backendapi.domain.post.application.service.PostService;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
+import org.sopt.pawkey.backendapi.domain.review.api.dto.response.ReviewResponseDto;
 import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,5 +40,6 @@ public class PostQueryFacade {
 
 		return postQueryService.getPostDetail(post, isLiked, routeMapImageUrl, walkingImages);
 	}
+
 
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/api/dto/response/ReviewResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/api/dto/response/ReviewResponseDto.java
@@ -1,0 +1,62 @@
+package org.sopt.pawkey.backendapi.domain.review.api.dto.response;
+
+import java.util.List;
+
+public record ReviewResponseDto(
+	String code,
+	String message,
+	Data data
+) {
+
+	public static ReviewResponseDto createMock() {
+		return new ReviewResponseDto(
+			"S000",
+			"요청 처리 성공",
+			new Data(
+				123L,
+				42,
+				List.of(
+					new CategoryTop(
+						1L,
+						"안전",
+						2L,
+						"차량이 거의 다니지 않아요",
+						1,
+						42
+					),
+					new CategoryTop(
+						1L,
+						"안전",
+						3L,
+						"킥보드가 거의 없어요",
+						2,
+						37
+					),
+					new CategoryTop(
+						2L,
+						"편리성",
+						7L,
+						"조명이 밝아요",
+						3,
+						35
+					)
+				)
+			)
+		);
+	}
+
+	public record Data(
+		Long postId,
+		int totalReviewCount,
+		List<CategoryTop> categoryTop3
+	) {}
+
+	public record CategoryTop(
+		Long categoryId,
+		String categoryName,
+		Long categoryOptionId,
+		String optionText,
+		int rank,
+		int percentage
+	) {}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/facade/ReviewRegisterFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/facade/ReviewRegisterFacade.java
@@ -24,7 +24,6 @@ public class ReviewRegisterFacade {
 
 		UserEntity user = userService.findById(userId);
 		RouteEntity route = routeService.getRouteById(command.routeId());
-
 		ReviewEntity review = reviewService.saveReview(command, user, route);
 
 	}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/controller/RouteController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/controller/RouteController.java
@@ -2,6 +2,7 @@ package org.sopt.pawkey.backendapi.domain.routes.api.controller;
 
 import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
 
+import org.sopt.pawkey.backendapi.domain.review.api.dto.response.ReviewResponseDto;
 import org.sopt.pawkey.backendapi.domain.routes.api.dto.GetRouteInfoForPostResponse;
 import org.sopt.pawkey.backendapi.domain.routes.api.dto.GetSharedRouteMapDataResponseDto;
 import org.sopt.pawkey.backendapi.domain.routes.api.dto.RouteRegisterRequest;
@@ -15,6 +16,7 @@ import org.sopt.pawkey.backendapi.domain.routes.application.facade.command.Route
 import org.sopt.pawkey.backendapi.domain.routes.application.facade.query.GetRouteInfoForPostFacade;
 import org.sopt.pawkey.backendapi.domain.routes.application.facade.query.GetSharedRouteMapDataFacade;
 import org.sopt.pawkey.backendapi.global.response.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,8 +29,10 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -94,4 +98,7 @@ public class RouteController {
 
 		return ResponseEntity.ok(ApiResponse.success(GetRouteInfoForPostResponse.from(result)));
 	}
+
+
+
 }


### PR DESCRIPTION
## 📌 PR 제목
[feat] 리뷰 top3조회 api 추가
---

## ✨ 요약 설명
리뷰 top3조회 api 추가했습니다.

---

## 🧾 변경 사항


---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [x] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 도입해 보고 싶은 것이 많은데, 시간 쫓기면서 하고싶지 않아 일단 목데이터로 조회 가능하게 해놨습니당
- 천천히 로직은 완성할게유
---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #102 
- Fix #102 