### PR TITLE
[fix] Category 엔티티에 order,description 항목 추가

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/api/dto/response/CategoryResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/api/dto/response/CategoryResponseDto.java
@@ -6,6 +6,7 @@ import org.sopt.pawkey.backendapi.domain.category.application.dto.result.Categor
 
 public record CategoryResponseDto(
 	Long categoryId,
+	String categoryDescription,
 	String categoryName,
 	List<CategoryOptionResponseDto> categoryOptions
 
@@ -13,6 +14,7 @@ public record CategoryResponseDto(
 	public static CategoryResponseDto from(CategoryResult categoryResult) {
 		return new CategoryResponseDto(
 			categoryResult.categoryId(),
+			categoryResult.categoryDescription(),
 			categoryResult.categoryName(),
 			categoryResult.options().stream()
 				.map(CategoryOptionResponseDto::from)

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/application/dto/result/CategoryResult.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/application/dto/result/CategoryResult.java
@@ -7,6 +7,7 @@ import org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity.Categ
 
 public record CategoryResult(
 	Long categoryId,
+	String categoryDescription,
 	String categoryName,
 	List<CategoryOptionResult> options
 
@@ -15,6 +16,7 @@ public record CategoryResult(
 	public static CategoryResult fromEntity(CategoryEntity categoryEntity) {
 		return new CategoryResult(
 			categoryEntity.getCategoryId(),
+			categoryEntity.getCategoryDescription(),
 			categoryEntity.getCategoryName(),
 			categoryEntity.getCategoryOptionEntityList().stream()
 				.map(CategoryOptionResult::fromEntity)
@@ -25,6 +27,7 @@ public record CategoryResult(
 	public static CategoryResult fromEntityWithSummary(CategoryEntity categoryEntity) {
 		return new CategoryResult(
 			categoryEntity.getCategoryId(),
+			categoryEntity.getCategoryDescription(),
 			categoryEntity.getCategoryName(),
 			categoryEntity.getCategoryOptionEntityList().stream()
 				.map(CategoryOptionResult::fromEntityWithSummary)

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/domain/repository/CategoryRepository.java
@@ -6,4 +6,7 @@ import org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity.Categ
 
 public interface CategoryRepository {
 	List<CategoryEntity> findAllCategoryWithOptions();
+
+
+
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/entity/CategoryEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/entity/CategoryEntity.java
@@ -34,7 +34,15 @@ public class CategoryEntity extends BaseEntity {
 	@Column(name = "category_name", nullable = false)
 	private String categoryName;
 
+	@Column(name = "display_order", nullable = false)
+	private Integer displayOrder;
+
+	@Column(name = "category_description", nullable = false)
+	private String categoryDescription;
+
+
 	@OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
 	@OrderBy("id ASC")
 	private List<CategoryOptionEntity> categoryOptionEntityList = new ArrayList<>();
 }
+

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/repository/CategoryRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/repository/CategoryRepositoryImpl.java
@@ -18,4 +18,6 @@ public class CategoryRepositoryImpl implements CategoryRepository {
 	public List<CategoryEntity> findAllCategoryWithOptions() {
 		return jpaRepository.findAllWithOptions();
 	}
+
+
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/repository/SpringDataCategoryRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/repository/SpringDataCategoryRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface SpringDataCategoryRepository extends JpaRepository<CategoryEntity, Long> {
-	@Query("SELECT DISTINCT c FROM CategoryEntity c JOIN FETCH c.categoryOptionEntityList")
+	@Query("SELECT DISTINCT c FROM CategoryEntity c " +
+		"JOIN FETCH c.categoryOptionEntityList " +
+		"ORDER BY c.displayOrder ASC")
 	List<CategoryEntity> findAllWithOptions();
+
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
@@ -62,7 +62,6 @@ public class UserController {
 	public ResponseEntity<ApiResponse<UserRegisterResponseDto>> createUser(
 		@RequestHeader(USER_ID_HEADER) @NotNull Integer userId,
 		@RequestPart("data") @Valid @NotNull CreateUserRequestDto requestDto,
-
 		@RequestPart("pet_profile") @Valid @NotNull MultipartFile image) {
 		UserRegisterCommand command = requestDto.toCommand();
 		UserRegisterResponseDto response = userRegisterFacade.execute(command, image);


### PR DESCRIPTION
## 📌 PR 제목
[feat] Category 엔티티에 order,description 항목 추가
---

## ✨ 요약 설명
게시물 등록> 카테고리 리스트 조회 항목에서 순서가 뒤죽박죽인 부분이 있어, 필드를 추가했습니다.


---

## 🧾 변경 사항
Category엔티티에 순서 필드(display_order)와 카테고리 질문(category_description)을 추가했습니다.

---

## 📂 PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 기타 (직접 작성: 엔티티 필드 추가 )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [x] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #109 
- Fix #109 