### PR TITLE
[feat] 게시물 등록 시 카테고리 옵션 선택 데이터 저장 하도록 수정

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/dto/request/PostCreateRequestDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/dto/request/PostCreateRequestDto.java
@@ -5,9 +5,6 @@ import java.util.List;
 import org.sopt.pawkey.backendapi.domain.post.application.dto.command.PostRegisterCommand;
 import org.sopt.pawkey.backendapi.domain.post.application.dto.command.SelectedOptionsForCategory;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/command/PostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/command/PostQueryFacade.java
@@ -7,7 +7,6 @@ import org.sopt.pawkey.backendapi.domain.post.api.dto.response.PostResponseDto;
 import org.sopt.pawkey.backendapi.domain.post.application.service.PostQueryService;
 import org.sopt.pawkey.backendapi.domain.post.application.service.PostService;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
-import org.sopt.pawkey.backendapi.domain.review.api.dto.response.ReviewResponseDto;
 import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,6 +39,5 @@ public class PostQueryFacade {
 
 		return postQueryService.getPostDetail(post, isLiked, routeMapImageUrl, walkingImages);
 	}
-
 
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/command/PostRegisterFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/command/PostRegisterFacade.java
@@ -50,10 +50,11 @@ public class PostRegisterFacade {
 				.flatMap(selectedOptionsForCategory -> selectedOptionsForCategory.getSelectedOptionIds().stream())
 				.toList();
 
-			List<CategoryOptionEntity> selectedCategoryOptions = categoryOptionService.getAllWhereInIds(selectedOptionIds);
+			List<CategoryOptionEntity> selectedCategoryOptions = categoryOptionService.getAllWhereInIds(
+				selectedOptionIds);
 
 			postSelectedCategoryOptionService.saveSelectedOption(post, selectedCategoryOptions);
-			
+
 			return PostRegisterResponseDto.from(post);
 		} catch (Exception e) {
 			// 이미지 rollback

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/command/PostRegisterFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/command/PostRegisterFacade.java
@@ -2,10 +2,14 @@ package org.sopt.pawkey.backendapi.domain.post.application.facade.command;
 
 import java.util.List;
 
+import org.sopt.pawkey.backendapi.domain.category.application.service.CategoryOptionService;
+import org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity.CategoryOptionEntity;
 import org.sopt.pawkey.backendapi.domain.image.application.service.command.ImageService;
 import org.sopt.pawkey.backendapi.domain.image.infra.persistence.entity.ImageEntity;
 import org.sopt.pawkey.backendapi.domain.post.api.dto.response.PostRegisterResponseDto;
 import org.sopt.pawkey.backendapi.domain.post.application.dto.command.PostRegisterCommand;
+import org.sopt.pawkey.backendapi.domain.post.application.dto.command.SelectedOptionsForCategory;
+import org.sopt.pawkey.backendapi.domain.post.application.service.PostSelectedCategoryOptionService;
 import org.sopt.pawkey.backendapi.domain.post.application.service.PostService;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
 import org.sopt.pawkey.backendapi.domain.routes.application.service.RouteService;
@@ -26,6 +30,8 @@ public class PostRegisterFacade {
 	private final RouteService routeService;
 	private final ImageService imageService;
 	private final PostService postService;
+	private final PostSelectedCategoryOptionService postSelectedCategoryOptionService;
+	private final CategoryOptionService categoryOptionService;
 
 	public PostRegisterResponseDto execute(Long userId,
 		PostRegisterCommand command,
@@ -34,11 +40,20 @@ public class PostRegisterFacade {
 		UserEntity writer = userService.findById(userId);
 		RouteEntity route = routeService.getRouteById(command.routeId());
 
-		// ✅ 이미지 저장
 		List<ImageEntity> imageEntities = imageService.storeWalkPostImages(postImages);
 
 		try {
 			PostEntity post = postService.savePost(writer, command, route, imageEntities);
+			List<SelectedOptionsForCategory> selectedOptionsForCategories = command.selectedOptionsForCategories();
+
+			List<Long> selectedOptionIds = selectedOptionsForCategories.stream()
+				.flatMap(selectedOptionsForCategory -> selectedOptionsForCategory.getSelectedOptionIds().stream())
+				.toList();
+
+			List<CategoryOptionEntity> selectedCategoryOptions = categoryOptionService.getAllWhereInIds(selectedOptionIds);
+
+			postSelectedCategoryOptionService.saveSelectedOption(post, selectedCategoryOptions);
+			
 			return PostRegisterResponseDto.from(post);
 		} catch (Exception e) {
 			// 이미지 rollback

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/service/PostSelectedCategoryOptionService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/service/PostSelectedCategoryOptionService.java
@@ -1,0 +1,30 @@
+package org.sopt.pawkey.backendapi.domain.post.application.service;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity.CategoryOptionEntity;
+import org.sopt.pawkey.backendapi.domain.post.domain.repository.PostSelectedCategoryOptionRepository;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostSelectedCategoryOptionEntity;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PostSelectedCategoryOptionService {
+	private final PostSelectedCategoryOptionRepository postSelectedCategoryOptionRepository;
+
+	public void saveSelectedOption(PostEntity post, List<CategoryOptionEntity> selectedOptions) {
+
+		List<PostSelectedCategoryOptionEntity> postSelectedCategoryOptions = selectedOptions.stream()
+			.map(selectedOption -> PostSelectedCategoryOptionEntity
+				.builder()
+				.post(post)
+				.categoryOption(selectedOption)
+				.build())
+			.toList();
+
+		postSelectedCategoryOptionRepository.saveBatch(postSelectedCategoryOptions);
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/domain/repository/PostSelectedCategoryOptionRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/domain/repository/PostSelectedCategoryOptionRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.pawkey.backendapi.domain.post.domain.repository;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostSelectedCategoryOptionEntity;
+
+public interface PostSelectedCategoryOptionRepository {
+	void saveBatch(List<PostSelectedCategoryOptionEntity> postSelectedCategoryOptions);
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/entity/PostSelectedCategoryOptionEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/entity/PostSelectedCategoryOptionEntity.java
@@ -14,6 +14,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,6 +23,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class PostSelectedCategoryOptionEntity extends BaseEntity {
 
 	@Id

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/PostSelectedCategoryOptionRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/PostSelectedCategoryOptionRepositoryImpl.java
@@ -1,0 +1,20 @@
+package org.sopt.pawkey.backendapi.domain.post.infra.persistence.repository;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.post.domain.repository.PostSelectedCategoryOptionRepository;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostSelectedCategoryOptionEntity;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class PostSelectedCategoryOptionRepositoryImpl implements PostSelectedCategoryOptionRepository {
+	private final SpringDataPostSelectedCategoryOptionRepository springDataPostSelectedCategoryOptionRepository;
+
+	@Override
+	public void saveBatch(List<PostSelectedCategoryOptionEntity> postSelectedCategoryOptions) {
+		springDataPostSelectedCategoryOptionRepository.saveAll(postSelectedCategoryOptions);
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/SpringDataPostSelectedCategoryOptionRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/SpringDataPostSelectedCategoryOptionRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.pawkey.backendapi.domain.post.infra.persistence.repository;
+
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostSelectedCategoryOptionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataPostSelectedCategoryOptionRepository
+	extends JpaRepository<PostSelectedCategoryOptionEntity, Long> {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/application/service/CategoryOptionService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/application/service/CategoryOptionService.java
@@ -1,0 +1,20 @@
+package org.sopt.pawkey.backendapi.domain.category.application.service;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.category.domain.repository.CategoryOptionRepository;
+import org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity.CategoryOptionEntity;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryOptionService {
+	private final CategoryOptionRepository categoryOptionRepository;
+
+	public List<CategoryOptionEntity> getAllWhereInIds(List<Long> selectedOptionIds) {
+
+		return categoryOptionRepository.findAllWhereInIds(selectedOptionIds);
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/domain/repository/CategoryOptionRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/domain/repository/CategoryOptionRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.pawkey.backendapi.domain.category.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity.CategoryOptionEntity;
@@ -8,4 +9,5 @@ public interface CategoryOptionRepository {
 
 	Optional<CategoryOptionEntity> findById(Long optionId);
 
+	List<CategoryOptionEntity> findAllWhereInIds(List<Long> selectedOptionIds);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/domain/repository/CategoryRepository.java
@@ -7,6 +7,4 @@ import org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity.Categ
 public interface CategoryRepository {
 	List<CategoryEntity> findAllCategoryWithOptions();
 
-
-
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/entity/CategoryEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/entity/CategoryEntity.java
@@ -40,7 +40,6 @@ public class CategoryEntity extends BaseEntity {
 	@Column(name = "category_description", nullable = false)
 	private String categoryDescription;
 
-
 	@OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
 	@OrderBy("id ASC")
 	private List<CategoryOptionEntity> categoryOptionEntityList = new ArrayList<>();

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/repository/CategoryOptionRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/repository/CategoryOptionRepositoryImpl.java
@@ -1,5 +1,6 @@
 package org.sopt.pawkey.backendapi.domain.category.infra.persistence.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.sopt.pawkey.backendapi.domain.category.domain.repository.CategoryOptionRepository;
@@ -16,5 +17,11 @@ public class CategoryOptionRepositoryImpl implements CategoryOptionRepository {
 	@Override
 	public Optional<CategoryOptionEntity> findById(Long optionId) {
 		return jpaRepository.findById(optionId);
+	}
+
+	@Override
+	public List<CategoryOptionEntity> findAllWhereInIds(List<Long> selectedOptionIds) {
+		List<CategoryOptionEntity> byIdIn = jpaRepository.findByIdIn(selectedOptionIds);
+		return byIdIn;
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/repository/CategoryRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/repository/CategoryRepositoryImpl.java
@@ -19,5 +19,4 @@ public class CategoryRepositoryImpl implements CategoryRepository {
 		return jpaRepository.findAllWithOptions();
 	}
 
-
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/repository/SpringDataCategoryOptionRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/infra/persistence/repository/SpringDataCategoryOptionRepository.java
@@ -1,7 +1,14 @@
 package org.sopt.pawkey.backendapi.domain.category.infra.persistence.repository;
 
+import java.util.List;
+
 import org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity.CategoryOptionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SpringDataCategoryOptionRepository extends JpaRepository<CategoryOptionEntity, Long> {
+
+	@Query("SELECT c FROM CategoryOptionEntity c WHERE c.id IN :ids")
+	List<CategoryOptionEntity> findByIdIn(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/api/dto/response/ReviewResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/api/dto/response/ReviewResponseDto.java
@@ -49,7 +49,8 @@ public record ReviewResponseDto(
 		Long postId,
 		int totalReviewCount,
 		List<CategoryTop> categoryTop3
-	) {}
+	) {
+	}
 
 	public record CategoryTop(
 		Long categoryId,
@@ -58,5 +59,6 @@ public record ReviewResponseDto(
 		String optionText,
 		int rank,
 		int percentage
-	) {}
+	) {
+	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/controller/RouteController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/controller/RouteController.java
@@ -2,7 +2,6 @@ package org.sopt.pawkey.backendapi.domain.routes.api.controller;
 
 import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
 
-import org.sopt.pawkey.backendapi.domain.review.api.dto.response.ReviewResponseDto;
 import org.sopt.pawkey.backendapi.domain.routes.api.dto.GetRouteInfoForPostResponse;
 import org.sopt.pawkey.backendapi.domain.routes.api.dto.GetSharedRouteMapDataResponseDto;
 import org.sopt.pawkey.backendapi.domain.routes.api.dto.RouteRegisterRequest;
@@ -16,7 +15,6 @@ import org.sopt.pawkey.backendapi.domain.routes.application.facade.command.Route
 import org.sopt.pawkey.backendapi.domain.routes.application.facade.query.GetRouteInfoForPostFacade;
 import org.sopt.pawkey.backendapi.domain.routes.application.facade.query.GetSharedRouteMapDataFacade;
 import org.sopt.pawkey.backendapi.global.response.ApiResponse;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,10 +27,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -98,7 +94,5 @@ public class RouteController {
 
 		return ResponseEntity.ok(ApiResponse.success(GetRouteInfoForPostResponse.from(result)));
 	}
-
-
 
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/facade/query/GetRouteInfoForPostFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/facade/query/GetRouteInfoForPostFacade.java
@@ -25,6 +25,22 @@ public class GetRouteInfoForPostFacade {
 	private final UserService userService;
 	private final RouteService routeService;
 
+	private static String getFormattedDate(LocalDateTime date) {
+		return date
+			.format(DateTimeFormatter.ofPattern("yyyy.MM.dd(E) | a hh:mm")
+				.withLocale(Locale.KOREAN));
+	}
+
+	private static String formatDistance(int meters) {
+		double km = meters / 1000.0;
+		return String.format("%.1fkm", km);
+	}
+
+	private static String formatDuration(int seconds) {
+		int minutes = seconds / 60;
+		return minutes + "분";
+	}
+
 	public GetRouteInfoForPostResult execute(Long userId, GetRouteInfoForPostCommand getRouteInfoForPostCommand) {
 		UserEntity user = userService.findById(userId);
 
@@ -49,22 +65,6 @@ public class GetRouteInfoForPostFacade {
 				.build(),
 			pet.getName()
 		);
-	}
-
-	private static String getFormattedDate(LocalDateTime date) {
-		return date
-			.format(DateTimeFormatter.ofPattern("yyyy.MM.dd(E) | a hh:mm")
-				.withLocale(Locale.KOREAN));
-	}
-
-	private static String formatDistance(int meters) {
-		double km = meters / 1000.0;
-		return String.format("%.1fkm", km);
-	}
-
-	private static String formatDuration(int seconds) {
-		int minutes = seconds / 60;
-		return minutes + "분";
 	}
 
 	private String formatSteps(Integer stepCount) {


### PR DESCRIPTION
## 📌 PR 제목
ex) [feat] 회원가입 API 구현  
ex) [bug] JWT 검증 오류 수정  
ex) [refactor] 응답 포맷 통일

---

## ✨ 요약 설명
게시물 등록 시 카테고리 옵션 선택 데이터 저장 하도록 수정

---

## 🧾 변경 사항
- 게시물 등록 시 카테고리 옵션 데이터 등록하도록 수정했습니다.
- TODO: 선택한 카테고리 옵션이 카테고리에 맞는지 validate 하는 로직이 필요합니다.
    - 파사드에서 진행할지, 서비스에서 진행할지 고민이네요,,
---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [x] 로컬 실행 결과 화면 캡처 포함
<img width="1417" height="477" alt="image" src="https://github.com/user-attachments/assets/5d44f1ad-f8d9-4401-a5a8-94fee52ac1f7" />


---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 리뷰할 때 집중해서 봐주었으면 하는 부분
- 고민 중인 로직 또는 개선점 등

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #이슈번호
- Fix #이슈번호