### PR TITLE
[feat] 마이페이지 유저 상세 정보 조회 api

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
@@ -9,12 +9,14 @@ import org.sopt.pawkey.backendapi.domain.post.api.dto.response.PostCardResponseD
 import org.sopt.pawkey.backendapi.domain.user.api.dto.request.CreateUserRequestDto;
 import org.sopt.pawkey.backendapi.domain.user.api.dto.request.UpdateUserRegionRequestDto;
 import org.sopt.pawkey.backendapi.domain.user.api.dto.response.ListResponseWrapper;
+import org.sopt.pawkey.backendapi.domain.user.api.dto.response.UserInfoResponseDto;
 import org.sopt.pawkey.backendapi.domain.user.api.dto.response.UserRegisterResponseDto;
 import org.sopt.pawkey.backendapi.domain.user.application.dto.request.UserRegisterCommand;
 import org.sopt.pawkey.backendapi.domain.user.application.facade.UserRegisterFacade;
 import org.sopt.pawkey.backendapi.domain.user.application.facade.command.UpdateUserRegionFacade;
 import org.sopt.pawkey.backendapi.domain.user.application.facade.query.UserLikedPostQueryFacade;
 import org.sopt.pawkey.backendapi.domain.user.application.facade.query.UserPetQueryFacade;
+import org.sopt.pawkey.backendapi.domain.user.application.facade.query.UserQueryFacade;
 import org.sopt.pawkey.backendapi.domain.user.application.facade.query.UserWrittenPostQueryFacade;
 import org.sopt.pawkey.backendapi.global.response.ApiResponse;
 import org.springframework.http.MediaType;
@@ -47,6 +49,8 @@ public class UserController {
 	private final UserLikedPostQueryFacade userLikedPostQueryFacade;
 	private final UserWrittenPostQueryFacade userWrittenPostQueryFacade;
 	private final UserRegisterFacade userRegisterFacade;
+	private final UserQueryFacade userQueryFacade;
+
 
 	@Operation(summary = "유저 정보 등록", description = "회원가입과 동시에, 유저 정보 등록. ", tags = {"Users"})
 	@ApiResponses({
@@ -82,6 +86,21 @@ public class UserController {
 		List<PostCardResponseDto> likedPosts = userLikedPostQueryFacade.getLikedPosts(userId);
 		return ResponseEntity.ok(ApiResponse.success(ListResponseWrapper.from(likedPosts)));
 	}
+
+	@Operation(summary = "마이페이지 유저 정보 조회", description = "마이페이지에서 유저 상세 정보를 조회합니다.", tags = {"Users"})
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자 없음"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	@GetMapping("/me/userInfo")
+	public ResponseEntity<ApiResponse<UserInfoResponseDto>> getUserProfile(
+		@RequestHeader("X-USER-ID") Long userId
+	) {
+		UserInfoResponseDto response = userQueryFacade.getUserInfo(userId);
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
 
 	@Operation(summary = "내가 작성한 게시물 조회", description = "사용자가 작성한 게시물 목록을 반환합니다.", tags = {"Users"})
 	@ApiResponses({

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/response/UserInfoResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/response/UserInfoResponseDto.java
@@ -1,0 +1,20 @@
+package org.sopt.pawkey.backendapi.domain.user.api.dto.response;
+
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+
+public record UserInfoResponseDto(
+	String name,
+	String gender,
+	int age,
+	String activeRegion
+) {
+	public static UserInfoResponseDto from(UserEntity user) {
+		return new UserInfoResponseDto(
+			user.getName(),
+			user.getGender(),
+			user.getAge(),
+			user.getRegion().getFullRegionName()
+
+		);
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserQueryFacade.java
@@ -1,0 +1,26 @@
+package org.sopt.pawkey.backendapi.domain.user.application.facade.query;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.pet.api.dto.response.PetProfileResponseDto;
+import org.sopt.pawkey.backendapi.domain.user.api.dto.response.UserInfoResponseDto;
+import org.sopt.pawkey.backendapi.domain.user.application.service.UserQueryService;
+import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserQueryFacade {
+	private final UserService userService;
+	private final UserQueryService userQueryService;
+
+	public UserInfoResponseDto getUserInfo(Long userId) {
+
+		return userQueryService.getUserInfo(userId);
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserQueryService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserQueryService.java
@@ -1,0 +1,16 @@
+package org.sopt.pawkey.backendapi.domain.user.application.service;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.pet.api.dto.response.PetProfileResponseDto;
+import org.sopt.pawkey.backendapi.domain.user.api.dto.response.UserInfoResponseDto;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+
+public interface UserQueryService {
+
+	UserInfoResponseDto getUserInfo(Long userId);
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserQueryServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserQueryServiceImpl.java
@@ -1,0 +1,29 @@
+package org.sopt.pawkey.backendapi.domain.user.application.service;
+
+import java.util.Optional;
+
+import org.sopt.pawkey.backendapi.domain.user.api.dto.response.UserInfoResponseDto;
+import org.sopt.pawkey.backendapi.domain.user.domain.repository.UserRepository;
+import org.sopt.pawkey.backendapi.domain.user.exception.UserBusinessException;
+import org.sopt.pawkey.backendapi.domain.user.exception.UserErrorCode;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserQueryServiceImpl implements UserQueryService{
+
+	private final UserRepository userRepository;
+
+	@Override
+	public UserInfoResponseDto getUserInfo(Long userId) {
+
+		UserEntity user = userRepository.findById(userId)
+			.orElseThrow(() -> new UserBusinessException(UserErrorCode.USER_NOT_FOUND));
+		return UserInfoResponseDto.from(user);
+
+
+	}
+}


### PR DESCRIPTION
## 📌 PR 제목
[feat] 마이페이지 유저 상세 정보 조회 api
---

## ✨ 요약 설명
 마이페이지에 강아지 정보 뿐만 아니라, 유저 정보도 조회할 수 있도록 api를 분리했습니다.

---

## 🧾 변경 사항
- Dto  추가
- Facade,Service 추가

---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [x] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말

---

## 🔗 관련 이슈

- Close #116 
- Fix #116 