### PR TITLE
[fix] PostCardResponseDto 관련 버그 해결

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/dto/response/PostCardResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/dto/response/PostCardResponseDto.java
@@ -1,6 +1,7 @@
 package org.sopt.pawkey.backendapi.domain.post.api.dto.response;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.sopt.pawkey.backendapi.domain.post.application.dto.result.GetPostCardResult;
@@ -10,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record PostCardResponseDto(
 	Long postId,
-	LocalDateTime createdAt,
+	String createdAt,
 	Boolean isLike,
 	String title,
 	String representativeImageUrl,
@@ -23,7 +24,7 @@ public record PostCardResponseDto(
 
 	public static PostCardResponseDto of(
 		Long postId,
-		LocalDateTime createdAt,
+		String createdAt,
 		Boolean isLike,
 		String title,
 		String representativeImageUrl,
@@ -47,7 +48,7 @@ public record PostCardResponseDto(
 	public static PostCardResponseDto from(GetPostCardResult result) {
 		return new PostCardResponseDto(
 			result.postId(),
-			result.createdAt(),
+			result.createdAt().format(DateTimeFormatter.ofPattern("yyyy/MM/dd")),
 			result.isLike(),
 			result.title(),
 			result.routeMapImageUrl(),

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/dto/response/PostCardResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/dto/response/PostCardResponseDto.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 import org.sopt.pawkey.backendapi.domain.post.application.dto.result.GetPostCardResult;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record PostCardResponseDto(
 	Long postId,
 	LocalDateTime createdAt,
@@ -13,7 +16,9 @@ public record PostCardResponseDto(
 	String representativeImageUrl,
 	Long routeId,
 	WriterDto writer,
-	List<String> descriptionTags
+	List<String> descriptionTags,
+
+	Boolean isPublic
 ) {
 
 	public static PostCardResponseDto of(
@@ -34,7 +39,8 @@ public record PostCardResponseDto(
 			representativeImageUrl,
 			routeId,
 			writer,
-			descriptionTags
+			descriptionTags,
+			null
 		);
 	}
 
@@ -51,7 +57,8 @@ public record PostCardResponseDto(
 				result.author().petName(),
 				result.author().petProfileImage()
 			),
-			result.categoryTags()
+			result.categoryTags(),
+			null
 		);
 	}
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/dto/response/PostCardResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/dto/response/PostCardResponseDto.java
@@ -1,6 +1,5 @@
 package org.sopt.pawkey.backendapi.domain.post.api.dto.response;
 
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/application/dto/result/CategoryResult.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/application/dto/result/CategoryResult.java
@@ -30,7 +30,7 @@ public record CategoryResult(
 	public static CategoryResult fromEntityWithSummary(CategoryEntity categoryEntity) {
 		return new CategoryResult(
 			categoryEntity.getCategoryId(),
-			categoryEntity.getCategoryDescription(),
+			null,
 			categoryEntity.getCategoryName(),
 			categoryEntity.getCategoryOptionEntityList().stream()
 				.map(CategoryOptionResult::fromEntityWithSummary)

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/domain/repository/SelectRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/domain/repository/SelectRepository.java
@@ -3,7 +3,6 @@ package org.sopt.pawkey.backendapi.domain.category.domain.repository;
 import java.util.List;
 
 import org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity.SelectEntity;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
@@ -3,10 +3,7 @@ package org.sopt.pawkey.backendapi.domain.user.application.facade.query;
 import java.util.Comparator;
 import java.util.List;
 
-import org.sopt.pawkey.backendapi.domain.image.infra.persistence.entity.ImageEntity;
 import org.sopt.pawkey.backendapi.domain.post.api.dto.response.PostCardResponseDto;
-import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
-import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostImageEntity;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostLikeEntity;
 import org.sopt.pawkey.backendapi.domain.user.application.service.UserLikedPostQueryService;
 import org.sopt.pawkey.backendapi.domain.user.domain.repository.UserQueryRepository;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
@@ -1,5 +1,6 @@
 package org.sopt.pawkey.backendapi.domain.user.application.facade.query;
 
+import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.List;
 
@@ -59,7 +60,7 @@ public class UserLikedPostQueryFacade {
 
 				return new PostCardResponseDto(
 					post.getPostId(),
-					post.getCreatedAt(),
+					post.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy/MM/dd")),
 					true, // 좋아요한 게시글
 					post.getTitle(),
 					repImageUrl,

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
@@ -32,8 +32,10 @@ public class UserLikedPostQueryFacade {
 		List<PostLikeEntity> likedPosts = userLikedPostQueryService.findLikedPostsByUserWithPostAndImages(userId)
 			.stream()
 			.sorted(Comparator.comparing(PostLikeEntity::getPostLikeId).reversed())
-
+			// 3. 비공개 게시물 필터링
+			.filter(postLike -> postLike.getPost().isPublic())
 			.toList();
+
 		// 4. DTO 변환
 		return likedPosts.stream()
 			.map(postLike -> {

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
@@ -63,7 +63,8 @@ public class UserLikedPostQueryFacade {
 					repImageUrl,
 					post.getRoute().getRouteId(),
 					writerDto,
-					descriptionTags
+					descriptionTags,
+					null
 				);
 			})
 			.toList();

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserWrittenPostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserWrittenPostQueryFacade.java
@@ -1,5 +1,6 @@
 package org.sopt.pawkey.backendapi.domain.user.application.facade.query;
 
+import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.List;
 
@@ -50,7 +51,7 @@ public class UserWrittenPostQueryFacade {
 
 				return new PostCardResponseDto(
 					post.getPostId(),
-					post.getCreatedAt(),
+					post.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy/MM/dd")),
 					null,
 					post.getTitle(),
 					repImageUrl,

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserWrittenPostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserWrittenPostQueryFacade.java
@@ -51,12 +51,13 @@ public class UserWrittenPostQueryFacade {
 				return new PostCardResponseDto(
 					post.getPostId(),
 					post.getCreatedAt(),
-					false, // isLike = false (내 게시글)
+					null,
 					post.getTitle(),
 					repImageUrl,
 					post.getRoute().getRouteId(),
 					writer,
-					tags
+					tags,
+					post.isPublic()
 				);
 			})
 			.toList();


### PR DESCRIPTION
## 📌 PR 제목
[fix] PostCardResponseDto 관련 버그 해결

---

## ✨ 요약 설명
- PostCardResponseDto의 필드를 일부 수정하여, 응답값을 올바르게 처리하였음

---

## 🧾 변경 사항
- PostCardResponseDto에 isPublic 필드 추가 및 isLike 필드 수정
- createAt 필드 타입 변경

---

## 📂 PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [x] 로컬 실행 결과 화면 캡처 포함
<img width="348" height="446" alt="image" src="https://github.com/user-attachments/assets/a66b1c26-5766-404c-97e7-4182732013b4" />

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 리뷰할 때 집중해서 봐주었으면 하는 부분
- 고민 중인 로직 또는 개선점 등

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #131 
- Fix #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 게시글 카드 정보에 게시글 공개 여부(`isPublic`)가 추가되었습니다.

* **버그 수정**
  * 게시글 생성일(`createdAt`)이 기존의 날짜/시간 형식에서 "yyyy/MM/dd" 형식의 문자열로 표시됩니다.
  * 게시글 카드 응답에서 좋아요 상태(`isLike`)가 더 이상 항상 false로 고정되지 않고, null로 처리됩니다.

* **기타**
  * 공개된 게시글만 좋아요 목록에 표시됩니다.
  * 게시글 카드 응답에서 null 값 필드는 응답에서 제외됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->