### PR TITLE
[feat] 리뷰 등록 후, 캐싱 테이블 갱신 로직 추가

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/facade/ReviewRegisterFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/facade/ReviewRegisterFacade.java
@@ -1,7 +1,9 @@
 package org.sopt.pawkey.backendapi.domain.review.application.facade;
 
 import org.sopt.pawkey.backendapi.domain.review.application.dto.command.ReviewRegisterCommand;
+import org.sopt.pawkey.backendapi.domain.review.application.service.ReviewCachingService;
 import org.sopt.pawkey.backendapi.domain.review.application.service.ReviewService;
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewCategoryOptionTop3Entity;
 import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewEntity;
 import org.sopt.pawkey.backendapi.domain.routes.application.service.RouteService;
 import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
@@ -18,13 +20,19 @@ public class ReviewRegisterFacade {
 	private final ReviewService reviewService;
 	private final UserService userService;
 	private final RouteService routeService;
+	private final ReviewCachingService reviewCachingService;
 
 	public void execute(Long userId,
 		ReviewRegisterCommand command) {
 
 		UserEntity user = userService.findById(userId);
 		RouteEntity route = routeService.getRouteById(command.routeId());
-		ReviewEntity review = reviewService.saveReview(command, user, route);
+		ReviewEntity review = reviewService.saveReview(command, user, route); //리뷰 생성
+
+
+		//Top3 캐싱 테이블 갱신
+		reviewCachingService.recalculateTop3ByRoute(route);
+
 
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/service/ReviewCachingService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/service/ReviewCachingService.java
@@ -1,0 +1,9 @@
+package org.sopt.pawkey.backendapi.domain.review.application.service;
+
+import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
+
+public interface ReviewCachingService {
+
+
+	void recalculateTop3ByRoute(RouteEntity route);
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/service/ReviewCachingServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/service/ReviewCachingServiceImpl.java
@@ -1,0 +1,48 @@
+package org.sopt.pawkey.backendapi.domain.review.application.service;
+
+import java.util.List;
+
+import org.sopt.pawkey.backendapi.domain.category.domain.repository.CategoryOptionRepository;
+import org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity.CategoryOptionEntity;
+import org.sopt.pawkey.backendapi.domain.review.domain.repository.ReviewCachingRepository;
+import org.sopt.pawkey.backendapi.domain.review.domain.repository.ReviewSelectedCategoryOptionRepository;
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewCategoryOptionTop3Entity;
+import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReviewCachingServiceImpl implements ReviewCachingService{
+
+	private final ReviewSelectedCategoryOptionRepository reviewSelectedCategoryOptionRepository;
+	private final ReviewCachingRepository reviewCachingRepository;
+
+	@Override
+	public void recalculateTop3ByRoute(RouteEntity route) {
+		reviewCachingRepository.deleteAllByRoute(route); //기존 데이터 삭제
+
+		//route에 대해 category_option_id별 선택 count 집계
+		List<Object[]> countResults = reviewSelectedCategoryOptionRepository.countCategoryOptionSelectionsByRoute(route.getRouteId());
+		log.info("countResults",countResults);
+
+
+		//상위 3개 추출
+
+		countResults.stream()
+			.limit(3)
+			.map(row -> ReviewCategoryOptionTop3Entity.builder()
+				.selectionCount(((Number) row[1]).intValue())
+				.route(route)
+				.categoryOption((CategoryOptionEntity) row[0])
+				.build())
+			.forEach(reviewCachingRepository::save);
+
+
+
+
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/service/ReviewServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/service/ReviewServiceImpl.java
@@ -41,7 +41,7 @@ public class ReviewServiceImpl implements ReviewService {
 			.route(route)
 			.build();
 
-		reviewRepository.save(review);
+		reviewRepository.save(review); //리뷰 저장
 
 		List<ReviewSelectedCategoryOptionEntity> selectedReviewOptionsForCategory = command.selectedReviewSetList()
 			.stream()
@@ -58,7 +58,7 @@ public class ReviewServiceImpl implements ReviewService {
 			)
 			.toList();
 
-		reviewSelectedCategoryOptionRepository.saveAll(selectedReviewOptionsForCategory);
+		reviewSelectedCategoryOptionRepository.saveAll(selectedReviewOptionsForCategory); //선택된 리뷰 저장
 		return review;
 
 	}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/domain/repository/ReviewCachingRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/domain/repository/ReviewCachingRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.pawkey.backendapi.domain.review.domain.repository;
+
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewCategoryOptionTop3Entity;
+import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
+
+public interface ReviewCachingRepository {
+	void deleteAllByRoute(RouteEntity route);
+	void save(ReviewCategoryOptionTop3Entity entity);
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/domain/repository/ReviewSelectedCategoryOptionRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/domain/repository/ReviewSelectedCategoryOptionRepository.java
@@ -3,8 +3,12 @@ package org.sopt.pawkey.backendapi.domain.review.domain.repository;
 import java.util.List;
 
 import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewSelectedCategoryOptionEntity;
+import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReviewSelectedCategoryOptionRepository {
 
 	void saveAll(List<ReviewSelectedCategoryOptionEntity> selectedCategoryOptionEntityList);
+	List<Object[]> countCategoryOptionSelectionsByRoute(Long routeId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/ReviewCachingRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/ReviewCachingRepositoryImpl.java
@@ -1,0 +1,26 @@
+package org.sopt.pawkey.backendapi.domain.review.infra.persistence;
+
+import org.sopt.pawkey.backendapi.domain.review.domain.repository.ReviewCachingRepository;
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewCategoryOptionTop3Entity;
+import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewCachingRepositoryImpl implements ReviewCachingRepository {
+	private final SpringDataReviewCategoryOptionTop3Repository jpaRepository;
+
+	@Override
+	public void deleteAllByRoute(RouteEntity route) {
+		jpaRepository.deleteAllByRoute(route);
+	}
+
+	@Override
+	public void save(ReviewCategoryOptionTop3Entity entity) {
+		jpaRepository.save(entity);
+	}
+
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/ReviewSelectedCategoryOptionRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/ReviewSelectedCategoryOptionRepositoryImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.sopt.pawkey.backendapi.domain.review.domain.repository.ReviewSelectedCategoryOptionRepository;
 import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewSelectedCategoryOptionEntity;
+import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
@@ -18,4 +19,10 @@ public class ReviewSelectedCategoryOptionRepositoryImpl implements ReviewSelecte
 	public void saveAll(List<ReviewSelectedCategoryOptionEntity> selectedCategoryOptionEntityList) {
 		jpaRepository.saveAll(selectedCategoryOptionEntityList);
 	}
+
+	@Override
+	public List<Object[]> countCategoryOptionSelectionsByRoute(Long routeId) {
+		return jpaRepository.countCategoryOptionSelectionsByRoute(routeId);
+	}
+
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/SpringDataReviewCategoryOptionTop3Repository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/SpringDataReviewCategoryOptionTop3Repository.java
@@ -1,0 +1,19 @@
+package org.sopt.pawkey.backendapi.domain.review.infra.persistence;
+
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewCategoryOptionTop3Entity;
+import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface SpringDataReviewCategoryOptionTop3Repository extends JpaRepository<ReviewCategoryOptionTop3Entity,Long> {
+
+
+	@Modifying
+	@Transactional
+	@Query("DELETE FROM ReviewCategoryOptionTop3Entity r WHERE r.route = :route")
+	void deleteAllByRoute(@Param("route") RouteEntity route);
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/SpringDataReviewSelectedCategoryOptionRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/SpringDataReviewSelectedCategoryOptionRepository.java
@@ -1,8 +1,21 @@
 package org.sopt.pawkey.backendapi.domain.review.infra.persistence;
 
+import java.util.List;
+
 import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewSelectedCategoryOptionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SpringDataReviewSelectedCategoryOptionRepository
 	extends JpaRepository<ReviewSelectedCategoryOptionEntity, Long> {
+
+	@Query("""
+		SELECT r.categoryOption, COUNT(r)
+		FROM ReviewSelectedCategoryOptionEntity r
+		WHERE r.review.route.routeId = :routeId
+		GROUP BY r.categoryOption
+		ORDER BY COUNT(r) DESC
+	""")
+	List<Object[]> countCategoryOptionSelectionsByRoute(@Param("routeId") Long routeId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/entity/ReviewCategoryOptionTop3Entity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/entity/ReviewCategoryOptionTop3Entity.java
@@ -1,0 +1,45 @@
+package org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity;
+
+import org.sopt.pawkey.backendapi.domain.category.infra.persistence.entity.CategoryOptionEntity;
+import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
+import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "review_category_option_top3")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class ReviewCategoryOptionTop3Entity extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "review_category_option_top3_id")
+	private Long id;
+
+	@Column(name = "selection_count", nullable = false)
+	private int selectionCount;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "route_id", nullable = false)
+	private RouteEntity route;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "category_option_id", nullable = false)
+	private CategoryOptionEntity categoryOption;
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/infra/persistence/entity/RouteEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/infra/persistence/entity/RouteEntity.java
@@ -1,17 +1,21 @@
 package org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.locationtech.jts.geom.LineString;
 import org.sopt.pawkey.backendapi.domain.image.infra.persistence.entity.ImageEntity;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewCategoryOptionTop3Entity;
 import org.sopt.pawkey.backendapi.domain.routes.exception.RouteBusinessException;
 import org.sopt.pawkey.backendapi.domain.routes.exception.RouteErrorCode;
 import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
 import org.sopt.pawkey.backendapi.global.util.GeoJsonUtil;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -20,6 +24,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -63,6 +68,9 @@ public class RouteEntity extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "image_id", nullable = true)
 	private ImageEntity trackingImage;
+
+	@OneToMany(mappedBy = "route", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+	private List<ReviewCategoryOptionTop3Entity> reviewCategoryOptionTop3EntityList = new ArrayList<>();
 
 	@Column(name = "started_at", nullable = false)
 	private LocalDateTime startedAt;


### PR DESCRIPTION
## 📌 PR 제목
[feat] 리뷰 등록 후, 캐싱 테이블 갱신 로직 추가

---

## ✨ 요약 설명
- 리뷰 등록 시, 선택된 카테고리 옵션을 기준으로 해당 루트(route)에 대한 리뷰 통계를 집계하고 review_category_option_top3 테이블을 실시간으로 갱신하는 로직을 추가했습니다.

- 현재는 리뷰 등록 직후 즉시 갱신되며, 추후에는 스케줄러 기반의 주기적 갱신으로 리팩토링할 계획입니다.

---

## 🧾 변경 사항
- ReviewRegisterFacade에서 리뷰 저장 후 캐싱 갱신 로직 연동
- ReviewCategoryOptionTop3Service 생성 및 Top3 재계산 로직 구현
- ReviewSelectedCategoryOptionRepository에 집계 쿼리 추가
- ReviewCategoryOptionTop3Repository에 route 기준 삭제 로직 추가
- 관련 서비스 및 레포지토리 테스트 데이터 추가

---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [x] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- recalculateTop3ByRoute() 트랜잭션 내부에서 동작하도록 구성되어 있어 정합성은 유지되지만, 성능 이슈가 있을 수 있으니 구조 개선 여지에 대한 의견 환영합니다.
- 추후 @Scheduled 기반 비동기 갱신 방식으로 리팩토링 예정입니다
- 쿼리 최적화나 인덱스 추가 등에 대한 피드백도 부탁드립니다.

---

## 🔗 관련 이슈

- Close #124 
- Fix #124 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 경로별로 리뷰 카테고리 옵션의 상위 3개를 자동으로 집계 및 캐싱하는 기능이 추가되었습니다.

* **버그 수정**
  * 없음

* **기타**
  * 리뷰 등록 시 상위 3개 카테고리 옵션 정보가 즉시 갱신되어 최신 데이터가 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->