### PR TITLE
[FEATURE] 필터링 리스트 조회 시, 내가 작성한 게시글인지 확인

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/dto/response/PostCardResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/dto/response/PostCardResponseDto.java
@@ -18,7 +18,8 @@ public record PostCardResponseDto(
 	WriterDto writer,
 	List<String> descriptionTags,
 
-	Boolean isPublic
+	Boolean isPublic,
+	Boolean isMine
 ) {
 
 	public static PostCardResponseDto of(
@@ -40,7 +41,9 @@ public record PostCardResponseDto(
 			routeId,
 			writer,
 			descriptionTags,
+			null,
 			null
+
 		);
 	}
 
@@ -58,7 +61,8 @@ public record PostCardResponseDto(
 				result.author().petProfileImage()
 			),
 			result.categoryTags(),
-			null
+			null,
+			result.isMine()
 		);
 	}
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/dto/result/GetPostCardResult.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/dto/result/GetPostCardResult.java
@@ -16,6 +16,7 @@ public record GetPostCardResult(
 	List<String> categoryTags,
 	LocalDateTime createdAt,
 	String routeMapImageUrl,
-	Long routeId
+	Long routeId,
+	Boolean isMine
 ) {
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/query/PostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/query/PostQueryFacade.java
@@ -11,7 +11,6 @@ import org.sopt.pawkey.backendapi.domain.post.application.dto.result.GetPostCard
 import org.sopt.pawkey.backendapi.domain.post.application.service.PostQueryService;
 import org.sopt.pawkey.backendapi.domain.post.application.service.PostService;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
-import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/query/PostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/facade/query/PostQueryFacade.java
@@ -23,7 +23,6 @@ import lombok.RequiredArgsConstructor;
 public class PostQueryFacade {
 	private final PostQueryService postQueryService;
 	private final PostService postService;
-	private final UserService userService;
 
 	public PostListResponseDto getFilterPostList(FilterPostsRequestDto requestDto, Long userId) {
 		List<GetPostCardResult> results = postQueryService.getFilteredPosts(requestDto, userId);

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/PostQueryRepositoryImpl.java
@@ -124,6 +124,7 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
 				.createdAt(p.getCreatedAt())
 				.routeMapImageUrl(p.getRoute().getTrackingImage().getImageUrl())
 				.routeId(p.getRoute().getRouteId())
+				.isMine(p.getUser().getUserId().equals(userId))
 				.build();
 		}).toList();
 	}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserLikedPostQueryFacade.java
@@ -67,6 +67,7 @@ public class UserLikedPostQueryFacade {
 					post.getRoute().getRouteId(),
 					writerDto,
 					descriptionTags,
+					null,
 					null
 				);
 			})

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserWrittenPostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/query/UserWrittenPostQueryFacade.java
@@ -58,7 +58,8 @@ public class UserWrittenPostQueryFacade {
 					post.getRoute().getRouteId(),
 					writer,
 					tags,
-					post.isPublic()
+					post.isPublic(),
+					null
 				);
 			})
 			.toList();


### PR DESCRIPTION
## 📌 PR 제목
[FEATURE] 필터링 리스트 조회 시, 내가 작성한 게시글인지 확인

---

## ✨ 요약 설명
게시글 리스트 반환시, 작성자 여부 판별하는 필드와 로직 추가

---

## 🧾 변경 사항
- PostCardResponseDto에 isMine 필드 추가 
- PostQueryRepositoryImpl에서 로그인한 유저와 게시글의 작성자의 일치 여부를 판별

---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [x] 로컬 실행 결과 화면 캡처 포함
<img width="429" height="436" alt="image" src="https://github.com/user-attachments/assets/780cd7c5-c4e8-4aef-80b9-673f03267345" />

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 로그인한 유저와 게시글 작성자의 일치 여부를 판별하는 위치가 PostQueryRepositoryImpl에서 이뤄지는데 적절한지 검토 부탁드리며, 더 나은 방향이 있을지 의견 주시면 감사하겠습니다!
- 현재 PostCardResponseDto를 통해 마이페이지와 필터링 관련 게시글 리스트를 반환하는데, 이때 달라지는 응답값에 따라 @JsonInclude(JsonInclude.Include.NON_NULL)을 이용해서 필요없는 필드에 값을 null로 반환하여 다른 응답값을 보내게 되는데 이 설계가 적당한지 궁금합니다.

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #138 
- Fix #138 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 게시글 카드 응답에 내가 작성한 게시글인지 여부를 나타내는 isMine 필드가 추가되었습니다.

* **버그 수정**
  * 일부 게시글 목록에서 isMine 정보가 누락되지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->