### PR TITLE
[fix] 유효성 검사 로직을 개선합니다.

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/controller/PostController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/controller/PostController.java
@@ -16,6 +16,7 @@ import org.sopt.pawkey.backendapi.global.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,6 +30,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 
@@ -49,9 +51,8 @@ public class PostController {
 	@PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
 	public ResponseEntity<ApiResponse<PostRegisterResponseDto>> createPost(
 		@RequestHeader(USER_ID_HEADER) @NotNull Integer userId,
-		@RequestPart("data") @Valid @NotNull PostCreateRequestDto requestDto,
-		@RequestPart("images") @Valid @NotNull List<MultipartFile> images
-
+		@RequestPart("data") @Validated @NotNull PostCreateRequestDto requestDto,
+		@RequestPart("images") @NotEmpty List<MultipartFile> images
 	) {
 		PostRegisterCommand command = requestDto.toCommand();
 		PostRegisterResult response = postRegisterFacade.execute(userId.longValue(), command, images);

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/controller/PostController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/api/controller/PostController.java
@@ -29,7 +29,6 @@ import org.springframework.web.multipart.MultipartFile;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/dto/result/PostRegisterResult.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/dto/result/PostRegisterResult.java
@@ -1,6 +1,5 @@
 package org.sopt.pawkey.backendapi.domain.post.application.dto.result;
 
-
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/service/PostServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/application/service/PostServiceImpl.java
@@ -11,7 +11,6 @@ import org.sopt.pawkey.backendapi.domain.post.exception.PostBusinessException;
 import org.sopt.pawkey.backendapi.domain.post.exception.PostErrorCode;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostImageEntity;
-import org.sopt.pawkey.backendapi.domain.routes.domain.repository.RouteRepository;
 import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
 import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.springframework.stereotype.Service;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/exception/PostErrorCode.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/exception/PostErrorCode.java
@@ -7,7 +7,7 @@ public enum PostErrorCode implements ErrorCode {
 
 	POST_NOT_FOUND("P40401", "존재하지 않는 게시글입니다.", HttpStatus.NOT_FOUND),
 	POST_WRITE_FORBIDDEN("P40301", "본인의 경로에 대해서만 게시글 작성이 가능합니다.", HttpStatus.FORBIDDEN),
-	ALREADY_ROUTE_POST_EXIST("P40901","이미 경로에 대한 게시물이 존재합니다." , HttpStatus.CONFLICT);
+	ALREADY_ROUTE_POST_EXIST("P40901", "이미 경로에 대한 게시물이 존재합니다.", HttpStatus.CONFLICT);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/facade/ReviewRegisterFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/facade/ReviewRegisterFacade.java
@@ -28,10 +28,8 @@ public class ReviewRegisterFacade {
 		RouteEntity route = routeService.getRouteById(command.routeId());
 		ReviewEntity review = reviewService.saveReview(command, user, route); //리뷰 생성
 
-
 		//Top3 캐싱 테이블 갱신
 		reviewCategoryOptionTop3Service.recalculateTop3ByRoute(route);
-
 
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/service/ReviewCategoryOptionTop3Service.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/service/ReviewCategoryOptionTop3Service.java
@@ -4,6 +4,5 @@ import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEn
 
 public interface ReviewCategoryOptionTop3Service {
 
-
 	void recalculateTop3ByRoute(RouteEntity route);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/service/ReviewCategoryOptionTop3ServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/service/ReviewCategoryOptionTop3ServiceImpl.java
@@ -10,9 +10,7 @@ import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEn
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ReviewCategoryOptionTop3ServiceImpl implements ReviewCategoryOptionTop3Service {
@@ -27,7 +25,6 @@ public class ReviewCategoryOptionTop3ServiceImpl implements ReviewCategoryOption
 		//route에 대해 category_option_id별 선택 count 집계
 		List<Object[]> countResults = reviewSelectedCategoryOptionRepository.countCategoryOptionSelectionsByRoute(
 			route.getRouteId());
-		log.info("countResults", countResults);
 
 		//상위 3개 추출
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/service/ReviewCategoryOptionTop3ServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/service/ReviewCategoryOptionTop3ServiceImpl.java
@@ -25,23 +25,20 @@ public class ReviewCategoryOptionTop3ServiceImpl implements ReviewCategoryOption
 		reviewCategoryOptionTop3Repository.deleteAllByRoute(route); //기존 데이터 삭제
 
 		//route에 대해 category_option_id별 선택 count 집계
-		List<Object[]> countResults = reviewSelectedCategoryOptionRepository.countCategoryOptionSelectionsByRoute(route.getRouteId());
-		log.info("countResults",countResults);
-
+		List<Object[]> countResults = reviewSelectedCategoryOptionRepository.countCategoryOptionSelectionsByRoute(
+			route.getRouteId());
+		log.info("countResults", countResults);
 
 		//상위 3개 추출
 
 		countResults.stream()
 			.limit(3)
 			.map(row -> ReviewCategoryOptionTop3Entity.builder()
-				.selectionCount(((Number) row[1]).intValue())
+				.selectionCount(((Number)row[1]).intValue())
 				.route(route)
-				.categoryOption((CategoryOptionEntity) row[0])
+				.categoryOption((CategoryOptionEntity)row[0])
 				.build())
 			.forEach(reviewCategoryOptionTop3Repository::save);
-
-
-
 
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/domain/repository/ReviewCategoryOptionTop3Repository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/domain/repository/ReviewCategoryOptionTop3Repository.java
@@ -5,5 +5,6 @@ import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEn
 
 public interface ReviewCategoryOptionTop3Repository {
 	void deleteAllByRoute(RouteEntity route);
+
 	void save(ReviewCategoryOptionTop3Entity entity);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/domain/repository/ReviewSelectedCategoryOptionRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/domain/repository/ReviewSelectedCategoryOptionRepository.java
@@ -3,12 +3,10 @@ package org.sopt.pawkey.backendapi.domain.review.domain.repository;
 import java.util.List;
 
 import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewSelectedCategoryOptionEntity;
-import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface ReviewSelectedCategoryOptionRepository {
 
 	void saveAll(List<ReviewSelectedCategoryOptionEntity> selectedCategoryOptionEntityList);
+
 	List<Object[]> countCategoryOptionSelectionsByRoute(Long routeId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/ReviewCategoryOptionTop3RepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/ReviewCategoryOptionTop3RepositoryImpl.java
@@ -22,5 +22,4 @@ public class ReviewCategoryOptionTop3RepositoryImpl implements ReviewCategoryOpt
 		jpaRepository.save(entity);
 	}
 
-
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/ReviewSelectedCategoryOptionRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/ReviewSelectedCategoryOptionRepositoryImpl.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.sopt.pawkey.backendapi.domain.review.domain.repository.ReviewSelectedCategoryOptionRepository;
 import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewSelectedCategoryOptionEntity;
-import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/SpringDataReviewCategoryOptionTop3Repository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/SpringDataReviewCategoryOptionTop3Repository.java
@@ -8,8 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
-public interface SpringDataReviewCategoryOptionTop3Repository extends JpaRepository<ReviewCategoryOptionTop3Entity,Long> {
-
+public interface SpringDataReviewCategoryOptionTop3Repository
+	extends JpaRepository<ReviewCategoryOptionTop3Entity, Long> {
 
 	@Modifying
 	@Transactional

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/SpringDataReviewSelectedCategoryOptionRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/SpringDataReviewSelectedCategoryOptionRepository.java
@@ -11,11 +11,11 @@ public interface SpringDataReviewSelectedCategoryOptionRepository
 	extends JpaRepository<ReviewSelectedCategoryOptionEntity, Long> {
 
 	@Query("""
-		SELECT r.categoryOption, COUNT(r)
-		FROM ReviewSelectedCategoryOptionEntity r
-		WHERE r.review.route.routeId = :routeId
-		GROUP BY r.categoryOption
-		ORDER BY COUNT(r) DESC
-	""")
+			SELECT r.categoryOption, COUNT(r)
+			FROM ReviewSelectedCategoryOptionEntity r
+			WHERE r.review.route.routeId = :routeId
+			GROUP BY r.categoryOption
+			ORDER BY COUNT(r) DESC
+		""")
 	List<Object[]> countCategoryOptionSelectionsByRoute(@Param("routeId") Long routeId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/controller/RouteController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/controller/RouteController.java
@@ -29,7 +29,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/controller/RouteController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/api/controller/RouteController.java
@@ -17,6 +17,7 @@ import org.sopt.pawkey.backendapi.domain.routes.application.facade.query.GetShar
 import org.sopt.pawkey.backendapi.global.response.ApiResponse;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -48,7 +49,7 @@ public class RouteController {
 	public ResponseEntity<ApiResponse<RouteRegisterResponse>> registerRoute(
 		@RequestHeader(USER_ID_HEADER) Long userId,
 		@RequestPart("trackingImage") MultipartFile trackingImage,
-		@Valid @RequestPart("routeRequest") RouteRegisterRequest routeRegisterRequest) {
+		@RequestPart("routeRequest") @Validated RouteRegisterRequest routeRegisterRequest) {
 
 		RouteRegisterResult result = routeRegisterFacade.execute(
 			userId,

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
@@ -21,6 +21,7 @@ import org.sopt.pawkey.backendapi.domain.user.application.facade.query.UserWritt
 import org.sopt.pawkey.backendapi.global.response.ApiResponse;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -61,8 +62,8 @@ public class UserController {
 
 	@PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
 	public ResponseEntity<ApiResponse<UserRegisterResponseDto>> createUser(
-		@RequestPart("data") @Valid CreateUserRequestDto requestDto,
-		@RequestPart("pet_profile") @Valid MultipartFile image) {
+		@RequestPart("data") @Validated CreateUserRequestDto requestDto,
+		@RequestPart("pet_profile") MultipartFile image) {
 
 		UserRegisterCommand command = requestDto.toCommand();
 		UserRegisterResponseDto response = userRegisterFacade.execute(command, image);

--- a/src/main/java/org/sopt/pawkey/backendapi/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/exception/handler/GlobalExceptionHandler.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import jakarta.validation.ConstraintViolationException;
@@ -76,6 +77,19 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity.status(ResponseCode.BAD_REQUEST.getStatus())
 			.body(ApiResponse.error(ResponseCode.BAD_REQUEST.getCode(), messages));
+	}
+
+	/**
+	 * 필수 multipart 파트 누락 예외를 처리합니다.
+	 */
+	@ExceptionHandler(MissingServletRequestPartException.class)
+	public ResponseEntity<ApiResponse<Void>> handleMissingPart(MissingServletRequestPartException ex) {
+
+		String partName = ex.getRequestPartName(); // ex.getMessage()는 전체 메시지
+		String message = String.format("필수 입력값 '%s'가 누락되었습니다.", partName);
+
+		return ResponseEntity.status(ResponseCode.BAD_REQUEST.getStatus())
+			.body(ApiResponse.error(ResponseCode.BAD_REQUEST.getCode(), message));
 	}
 
 	/**


### PR DESCRIPTION
Multipart 요청에 대한 유효성 검사 방식 개선: @Valid 대신 @Validated 사용 및 파일 리스트에 @NotEmpty 적용

기존 @Valid 어노테이션은 복잡한 Multipart 요청의 유효성 검증에 적합하지 않아, @Validated 어노테이션을 사용하여 컨트롤러 레벨에서 유효성 검사를 수행하도록 변경합니다.

PostController, RouteController, UserController에 적용되어 요청 데이터의 유효성을 보다 효과적으로 검사합니다.

또한, PostController에서 이미지 리스트가 비어있는 경우에 대한 유효성 검사를 위해 @NotEmpty 어노테이션을 추가합니다.

누락된 RequestPart 예외처리를 GlobalExceptionHandler에 추가하여, 필수 파트가 누락되었을 때 사용자에게 더 명확한 오류 메시지를 제공합니다.

## 📌 PR 제목
ex) [feat] 회원가입 API 구현  
ex) [bug] JWT 검증 오류 수정  
ex) [refactor] 응답 포맷 통일

---

## ✨ 요약 설명
이번 PR에서 무엇을 했는지 간단히 작성해주세요.

---

## 🧾 변경 사항
- 무엇을 추가/수정/삭제했나요?
- 어떤 파일 또는 모듈이 변경되었나요?

---

## 📂 PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [x] 로컬 실행 결과 화면 캡처 포함
<img width="1411" height="441" alt="image" src="https://github.com/user-attachments/assets/e768eacd-c41e-44cc-9ff7-a604e3b3885c" />

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 리뷰할 때 집중해서 봐주었으면 하는 부분
- 고민 중인 로직 또는 개선점 등

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 필수 multipart 요청 파트가 누락될 경우, 사용자에게 어떤 입력이 필요한지 명확히 안내하는 에러 메시지와 함께 400 오류가 반환됩니다.

* **스타일**
  * 코드 내 불필요한 공백 및 들여쓰기 등 포맷이 개선되어 가독성이 향상되었습니다.

* **리팩터**
  * multipart 요청 파라미터의 유효성 검증 방식이 일부 변경되어, DTO는 이제 `@Validated`로 검증되고, 이미지 리스트는 비어있지 않아야 합니다.
  * 일부 컨트롤러에서 유효성 검증 어노테이션이 `@Valid`에서 `@Validated`로 변경되었습니다.
  * 불필요한 import가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->