### PR TITLE
[feat] 대시보드> 현재 지역 조회 API

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/controller/RegionController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/controller/RegionController.java
@@ -4,11 +4,15 @@ import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
 
 import org.sopt.pawkey.backendapi.domain.region.api.dto.GetRegionCoordinatesResponseDto;
 import org.sopt.pawkey.backendapi.domain.region.api.dto.GetRegionListResponseDto;
+import org.sopt.pawkey.backendapi.domain.region.api.dto.GetRegionResponseDto;
+import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionCommand;
 import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionCoordinatesCommand;
 import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionListCommand;
 import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegionCoordinatesResult;
 import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegionListResult;
+import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegionResult;
 import org.sopt.pawkey.backendapi.domain.region.application.facade.query.GetRegionCoordinatesFacade;
+import org.sopt.pawkey.backendapi.domain.region.application.facade.query.GetRegionFacade;
 import org.sopt.pawkey.backendapi.domain.region.application.facade.query.GetRegionListFacade;
 import org.sopt.pawkey.backendapi.global.constants.AppConstants;
 import org.sopt.pawkey.backendapi.global.exception.BusinessException;
@@ -33,6 +37,7 @@ public class RegionController {
 
 	private final GetRegionCoordinatesFacade getRegionCoordinatesFacade;
 	private final GetRegionListFacade getRegionListFacade;
+	private final GetRegionFacade getRegionFacade;
 
 	@GetMapping
 	@Operation(summary = "지역구 리스트 조회", description = "검색 키워드로 지역구 리스트를 조회하는 API입니다.", tags = {"Region"})
@@ -46,6 +51,19 @@ public class RegionController {
 
 		return ResponseEntity.ok(
 			ApiResponse.success(GetRegionListResponseDto.from(result)));
+	}
+	@GetMapping("/current")
+	@Operation(summary = "현재 지역 조회", description = "대시보드에서 현재 지역을 조회하는 API입니다.", tags = {"Region"})
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "현재 지역 리스트 조회")
+	})
+	public ResponseEntity<ApiResponse<GetRegionResponseDto>> getCurrentRegion(
+		@RequestHeader(AppConstants.USER_ID_HEADER) Long userId
+	) {
+		GetRegionResult result = getRegionFacade.execute(userId);
+
+		return ResponseEntity.ok(
+			ApiResponse.success(GetRegionResponseDto.from(result)));
 	}
 
 	@GetMapping("/{regionId}/geometry")

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/dto/GetRegionResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/dto/GetRegionResponseDto.java
@@ -2,8 +2,8 @@ package org.sopt.pawkey.backendapi.domain.region.api.dto;
 
 import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegionResult;
 
-public record GetRegionResponseDto(String fullRegionName) {
+public record GetRegionResponseDto(Long currentRegionId,String fullRegionName) {
 	public static GetRegionResponseDto from(GetRegionResult result) {
-		return new GetRegionResponseDto(result.fullRegionName());
+		return new GetRegionResponseDto(result.regionId(),result.fullRegionName());
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/dto/GetRegionResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/dto/GetRegionResponseDto.java
@@ -1,0 +1,9 @@
+package org.sopt.pawkey.backendapi.domain.region.api.dto;
+
+import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegionResult;
+
+public record GetRegionResponseDto(String fullRegionName) {
+	public static GetRegionResponseDto from(GetRegionResult result) {
+		return new GetRegionResponseDto(result.fullRegionName());
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/command/GetRegionCommand.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/command/GetRegionCommand.java
@@ -1,6 +1,6 @@
 package org.sopt.pawkey.backendapi.domain.region.application.dto.command;
 
 public record GetRegionCommand(
-	Long regionId
+	Long userId
 ) {
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/command/GetRegionCommand.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/command/GetRegionCommand.java
@@ -1,0 +1,6 @@
+package org.sopt.pawkey.backendapi.domain.region.application.dto.command;
+
+public record GetRegionCommand(
+	Long regionId
+) {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/result/GetRegionResult.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/result/GetRegionResult.java
@@ -1,5 +1,6 @@
 package org.sopt.pawkey.backendapi.domain.region.application.dto.result;
 
 public record GetRegionResult(
+	Long regionId,
 	String fullRegionName
 ){}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/result/GetRegionResult.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/result/GetRegionResult.java
@@ -1,0 +1,5 @@
+package org.sopt.pawkey.backendapi.domain.region.application.dto.result;
+
+public record GetRegionResult(
+	String fullRegionName
+){}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/facade/query/GetRegionFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/facade/query/GetRegionFacade.java
@@ -18,7 +18,7 @@ public class GetRegionFacade {
 	public GetRegionResult execute(Long userId){
 		RegionEntity currentRegion = regionQueryService.getCurrentRegion(userId);
 
-		return new GetRegionResult(currentRegion.getFullRegionName());
+		return new GetRegionResult(currentRegion.getRegionId(),currentRegion.getFullRegionName());
 	}
 
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/facade/query/GetRegionFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/facade/query/GetRegionFacade.java
@@ -1,0 +1,24 @@
+package org.sopt.pawkey.backendapi.domain.region.application.facade.query;
+
+import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionCommand;
+import org.sopt.pawkey.backendapi.domain.region.application.dto.result.GetRegionResult;
+import org.sopt.pawkey.backendapi.domain.region.application.service.query.RegionQueryService;
+import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetRegionFacade {
+	private final RegionQueryService regionQueryService;
+
+	public GetRegionResult execute(Long userId){
+		RegionEntity currentRegion = regionQueryService.getCurrentRegion(userId);
+
+		return new GetRegionResult(currentRegion.getFullRegionName());
+	}
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/service/query/RegionQueryService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/service/query/RegionQueryService.java
@@ -1,10 +1,14 @@
 package org.sopt.pawkey.backendapi.domain.region.application.service.query;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionCommand;
 import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionListCommand;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 
 public interface RegionQueryService {
 	List<RegionEntity> searchGusWithRegion(GetRegionListCommand command);
+
+	RegionEntity  getCurrentRegion(Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/service/query/RegionQueryServiceImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/service/query/RegionQueryServiceImpl.java
@@ -1,10 +1,18 @@
 package org.sopt.pawkey.backendapi.domain.region.application.service.query;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionCommand;
 import org.sopt.pawkey.backendapi.domain.region.application.dto.command.GetRegionListCommand;
 import org.sopt.pawkey.backendapi.domain.region.domain.RegionQueryRepository;
+import org.sopt.pawkey.backendapi.domain.region.exception.RegionBusinessException;
+import org.sopt.pawkey.backendapi.domain.region.exception.RegionErrorCode;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
+import org.sopt.pawkey.backendapi.domain.user.domain.repository.UserRepository;
+import org.sopt.pawkey.backendapi.domain.user.exception.UserBusinessException;
+import org.sopt.pawkey.backendapi.domain.user.exception.UserErrorCode;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -14,10 +22,25 @@ import lombok.RequiredArgsConstructor;
 public class RegionQueryServiceImpl implements RegionQueryService {
 
 	private final RegionQueryRepository regionQueryRepository;
+	private  final UserRepository userRepository;
 
 	@Override
 	public List<RegionEntity> searchGusWithRegion(GetRegionListCommand command) {
 
 		return regionQueryRepository.findDistrictByRegionNameWithChildren(command.searchKeyword());
+	}
+
+	@Override
+	public RegionEntity getCurrentRegion(Long userId) {
+		UserEntity user = userRepository.findById(userId)
+			.orElseThrow(() -> new UserBusinessException(UserErrorCode.USER_NOT_FOUND));
+
+		RegionEntity region = user.getRegion();
+
+		if (region == null) {
+			throw new RegionBusinessException(RegionErrorCode.REGION_NOT_FOUND);
+		}
+
+		return region;
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/domain/RegionQueryRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/domain/RegionQueryRepository.java
@@ -1,9 +1,11 @@
 package org.sopt.pawkey.backendapi.domain.region.domain;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 
 public interface RegionQueryRepository {
 	List<RegionEntity> findDistrictByRegionNameWithChildren(String keyword);
+	Optional<RegionEntity> findCurrentRegionById(Long regionId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/infra/persistence/RegionQueryRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/infra/persistence/RegionQueryRepositoryImpl.java
@@ -1,6 +1,7 @@
 package org.sopt.pawkey.backendapi.domain.region.infra.persistence;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.sopt.pawkey.backendapi.domain.region.domain.RegionQueryRepository;
 import org.sopt.pawkey.backendapi.domain.region.domain.model.RegionType;
@@ -15,7 +16,9 @@ import lombok.RequiredArgsConstructor;
 @Repository
 @RequiredArgsConstructor
 public class RegionQueryRepositoryImpl implements RegionQueryRepository {
+	private final SpringDataRegionRepository springDataRegionRepository;
 	private final JPAQueryFactory queryFactory;
+
 
 	@Override
 	public List<RegionEntity> findDistrictByRegionNameWithChildren(String keyword) {
@@ -28,5 +31,10 @@ public class RegionQueryRepositoryImpl implements RegionQueryRepository {
 			.where(regionEntity.regionName.eq(keyword))
 			.leftJoin(regionEntity.childrenRegionList, childRegion).fetchJoin()
 			.fetch();
+	}
+
+	@Override
+	public Optional<RegionEntity> findCurrentRegionById(Long regionId) {
+		return springDataRegionRepository.findById(regionId);
 	}
 }


### PR DESCRIPTION
## 📌 PR 제목
[feat] 대시보드> 현재 지역 조회 API

---

## ✨ 요약 설명
대시보드에서 현재 선택한 지역 정보를 조회하는 api가 추가되었습니다.

---

## 🧾 변경 사항
- 무엇을 추가/수정/삭제했나요?
- 어떤 파일 또는 모듈이 변경되었나요?

---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [x] 로컬 실행 결과 화면 캡처 포함
<img width="581" height="212" alt="image" src="https://github.com/user-attachments/assets/19a562b2-9532-4257-872d-585d9babb0f1" />

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말

---

## 🔗 관련 이슈


- Close #146 
- Fix #146 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 현재 지역 정보를 조회할 수 있는 새로운 엔드포인트가 추가되었습니다. (GET /regions/current)
  * 사용자 ID를 기반으로 전체 지역명을 반환합니다.

* **버그 수정**
  * 해당 없음.

* **문서화**
  * 새로운 엔드포인트에 대한 OpenAPI 문서가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->