### PR TITLE
[BUG] 필터링 시, 산책 소요 시간 이슈처리

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/Post/infra/persistence/repository/PostQueryRepositoryImpl.java
@@ -63,12 +63,18 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
 		BooleanBuilder builder = new BooleanBuilder()
 			.and(post.isPublic.isTrue());
 
-		// duration이 null이 아닐 경우만 필터링 (분 → 초 변환)
-		if (dto.durationStart() != null && dto.durationEnd() != null) {
-			builder.and(route.duration.between(
-				dto.durationStart() * 60,
-				dto.durationEnd() * 60
-			));
+		// duration 필터 처리 (분 → 초)
+		if (dto.durationStart() != null || dto.durationEnd() != null) {
+			Integer startInSec = dto.durationStart() != null ? dto.durationStart() * 60 : null;
+			Integer endInSec = dto.durationEnd() != null ? dto.durationEnd() * 60 : null;
+
+			if (startInSec != null && endInSec != null) {
+				builder.and(route.duration.between(startInSec, endInSec));
+			} else if (startInSec != null) {
+				builder.and(route.duration.goe(startInSec));
+			} else if (endInSec != null) {
+				builder.and(route.duration.loe(endInSec));
+			}
 		}
 
 		// 필터링

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserService.java
@@ -1,9 +1,7 @@
 package org.sopt.pawkey.backendapi.domain.user.application.service;
 
-import org.sopt.pawkey.backendapi.domain.region.domain.RegionRepository;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 import org.sopt.pawkey.backendapi.domain.user.application.dto.request.CreateUserCommand;
-import org.sopt.pawkey.backendapi.domain.user.domain.repository.UserQueryRepository;
 import org.sopt.pawkey.backendapi.domain.user.domain.repository.UserRepository;
 import org.sopt.pawkey.backendapi.domain.user.exception.UserBusinessException;
 import org.sopt.pawkey.backendapi.domain.user.exception.UserErrorCode;


### PR DESCRIPTION
## 📌 PR 제목
[BUG] 필터링 시, 산책 소요 시간 이슈처리

---

## ✨ 요약 설명
산책 게시글 필터링을 진행할 때, 산책 소요 시간 필터링에 대한 버그를 해결하였습니다.

---

## 🧾 변경 사항
- PostQueryRepositoryImpl의 duration 처리를 조건에 따라 처리하였음.
---

## 📂 PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [x] 로컬 실행 결과 화면 캡처 포함
<img width="342" height="563" alt="image" src="https://github.com/user-attachments/assets/c1e34e4d-48ef-4b51-a76f-9e28b1c07166" />

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 리뷰할 때 집중해서 봐주었으면 하는 부분
- 고민 중인 로직 또는 개선점 등

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #158 
- Fix #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 게시글 검색 시 소요 시간 필터를 시작 또는 종료값 중 하나만 입력해도 적용되도록 개선되었습니다.  
* **정리**
  * 사용되지 않는 불필요한 import 문이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->