### PR TITLE
[feat] Google 소셜 로그인 및 JWT 인증 체계 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation 'com.h2database:h2'
 
     // swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,9 @@ dependencies {
     implementation 'com.h2database:h2'
 
     // swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+
 
     // s3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
@@ -81,8 +83,15 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-    // 소셜 로그인 토큰 검증(JWT 파싱/JWK 서명 검증) + Access/Refresh 발급
+    // 소셜 로그인 토큰 검증(JWT 파싱/JWK 서명 검증)
     implementation 'com.nimbusds:nimbus-jose-jwt:9.37'
+
+
+    // JWT (JJWT) - 내부 토큰 관리용
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
 }
 
 def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile;

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/category/api/controller/CategoryController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/category/api/controller/CategoryController.java
@@ -34,7 +34,8 @@ public class CategoryController {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json"))})
 	@GetMapping("")
 	public ResponseEntity<ApiResponse<CategoryListResponseDto>> getCategories(
-		@RequestHeader(USER_ID_HEADER) @NotNull Integer userId) {
+	)
+	{
 		List<CategoryResult> resultList = categoryQueryService.getAllCategories();
 		CategoryListResponseDto response = CategoryListResponseDto.from(resultList);
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response));

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/UserLoginFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/UserLoginFacade.java
@@ -1,0 +1,38 @@
+package org.sopt.pawkey.backendapi.domain.user.application.facade;
+
+import java.util.Map;
+
+import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
+import org.sopt.pawkey.backendapi.global.auth.api.dto.response.TokenResponseDTO;
+import org.sopt.pawkey.backendapi.global.auth.application.service.TokenService;
+import org.sopt.pawkey.backendapi.global.auth.application.verifier.GoogleVerifierService;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserLoginFacade {
+
+	private final UserService userService;
+	private final TokenService tokenService;
+	private final GoogleVerifierService googleVerifierService;
+	public TokenResponseDTO googleLogin(String idToken, String deviceId) {
+		// 1. 외부 시스템 연동 (Verifier는 4단계에서 구현 예정)
+		Map<String, String> socialUserInfo = googleVerifierService.verifyGoogleToken(idToken);
+
+
+		// 임시 더미 데이터 (Verifier 구현 전까지 사용)
+		String platformUserId = "dummyGoogleId12345";
+		String primaryEmail = "dummy@google.com";
+
+		// 2. 비즈니스 처리 (User 생성/조회)
+		// UserService는 User와 SocialAccount의 DB 트랜잭션만 책임집니다.
+		Long userId = userService.findOrCreateUserBySocialId("GOOGLE", platformUserId, primaryEmail);
+
+		// 3. 인프라 처리 (토큰 발급 및 Redis 저장)
+		// TokenService는 AccessToken과 RefreshToken이 담긴 DTO를 반환합니다.
+		return tokenService.issueTokens(userId, deviceId);
+	}
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserService.java
@@ -1,12 +1,17 @@
 package org.sopt.pawkey.backendapi.domain.user.application.service;
 
+import java.util.Optional;
+
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 import org.sopt.pawkey.backendapi.domain.user.application.dto.request.CreateUserCommand;
+import org.sopt.pawkey.backendapi.domain.user.domain.repository.SocialAccountRepository;
 import org.sopt.pawkey.backendapi.domain.user.domain.repository.UserRepository;
 import org.sopt.pawkey.backendapi.domain.user.exception.UserBusinessException;
 import org.sopt.pawkey.backendapi.domain.user.exception.UserErrorCode;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.SocialAccountEntity;
 import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 
 	private final UserRepository userRepository;
+	private final SocialAccountRepository socialAccountRepository;
 
 	public UserEntity findById(final Long id) {
 		return userRepository.findById(id)
@@ -41,8 +47,45 @@ public class UserService {
 
 	public void updateUserRegion(UserEntity user, RegionEntity region) {
 		user.updateRegion(region);
-
 	}
+
+	@Transactional
+	public Long findOrCreateUserBySocialId(String platform, String platformUserId, String primaryEmail) {
+		// 1. SocialAccount가 이미 존재하는지 확인 (로그인 시도)
+		Optional<SocialAccountEntity> existingAccount = socialAccountRepository.findByPlatformAndPlatformUserId(platform, platformUserId);
+
+		if (existingAccount.isPresent()) {
+			// 2. 존재하면, 연결된 User ID 반환 (로그인)
+			return existingAccount.get().getUser().getUserId();
+		} else {
+			// 3. 존재하지 않으면, 신규 가입 트랜잭션 수행
+
+			// 3-1. 새로운 User 엔티티 생성 (최소 정보만으로 생성)
+			UserEntity newUser = userRepository.save(UserEntity.builder()
+				.loginId(platform.toLowerCase() + "_" + platformUserId)
+				.name(platform + " User")
+				// 💡 추가 설정이 필요한 최소 필드:
+				.password("") // 소셜 사용자는 비밀번호가 없지만, NOT NULL일 경우 빈 문자열 또는 임시값 지정
+				.gender("UNKNOWN") // NOT NULL일 경우 임시값 설정
+				.age(0) // NOT NULL일 경우 기본값 0 설정
+				// RegionEntity는 ManyToOne이므로, 초기 가입 시에는 NULL을 유지하는 것이 맞음.
+				.build());
+
+			// 3-2. SocialAccount 엔티티 생성 및 User와 연결
+			SocialAccountEntity socialAccount = SocialAccountEntity.create(
+				newUser,
+				platform,
+				platformUserId,
+				primaryEmail
+			);
+			socialAccountRepository.save(socialAccount);
+
+			// 3-3. 신규 User ID 반환
+			return newUser.getUserId();
+		}
+	}
+
+
 }
 
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/domain/repository/SocialAccountRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/domain/repository/SocialAccountRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.pawkey.backendapi.domain.user.domain.repository;
+
+import java.util.Optional;
+
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.SocialAccountEntity;
+
+public interface SocialAccountRepository {
+
+	Optional<SocialAccountEntity> findByPlatformAndPlatformUserId(String platform, String platformUserId);
+
+	SocialAccountEntity save(SocialAccountEntity socialAccount);
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/SocialAccountRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/SocialAccountRepositoryImpl.java
@@ -1,0 +1,24 @@
+package org.sopt.pawkey.backendapi.domain.user.infra.persistence;
+
+import java.util.Optional;
+
+import org.sopt.pawkey.backendapi.domain.user.domain.repository.SocialAccountRepository;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.SocialAccountEntity;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class SocialAccountRepositoryImpl implements SocialAccountRepository {
+	private final SpringDataSocialAccountRepository jpaRepository;
+	@Override
+	public Optional<SocialAccountEntity> findByPlatformAndPlatformUserId(String platform, String platformUserId) {
+		return jpaRepository.findByPlatformAndPlatformUserId(platform, platformUserId);
+	}
+
+	@Override
+	public SocialAccountEntity save(SocialAccountEntity socialAccount) {
+		return jpaRepository.save(socialAccount);
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/SpringDataSocialAccountRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/SpringDataSocialAccountRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.pawkey.backendapi.domain.user.infra.persistence;
+
+import java.util.Optional;
+
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.SocialAccountEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataSocialAccountRepository extends JpaRepository<SocialAccountEntity,Long> {
+
+	Optional<SocialAccountEntity> findByPlatformAndPlatformUserId(String platform, String platformUserId);
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/SpringDataUserRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/SpringDataUserRepository.java
@@ -4,6 +4,5 @@ import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntit
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SpringDataUserRepository extends JpaRepository<UserEntity, Long> {
-
 	UserEntity getByUserId(Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/SocialAccount.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/SocialAccount.java
@@ -1,0 +1,8 @@
+package org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity;
+
+public class SocialAccount {
+
+
+
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/SocialAccount.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/SocialAccount.java
@@ -1,8 +1,0 @@
-package org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity;
-
-public class SocialAccount {
-
-
-
-
-}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/SocialAccountEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/SocialAccountEntity.java
@@ -1,0 +1,65 @@
+package org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity;
+
+import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "social_account", uniqueConstraints = {
+	@UniqueConstraint(columnNames = {"platform", "platform_user_id"})
+})
+public class SocialAccountEntity extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private UserEntity user;
+
+	@Column(nullable = false, length = 20)
+	private String platform; // KAKAO, GOOGLE, APPLE
+
+	@Column(name = "platform_user_id", nullable = false, length = 64)
+	private String platformUserId; // 소셜에서 받은 고유 ID (sub, id 등)
+
+	@Column(name = "primary_email", length = 255)
+	private String primaryEmail;
+
+	@Builder
+	private SocialAccountEntity(UserEntity user, String platform, String platformUserId, String primaryEmail) {
+		this.user = user;
+		this.platform = platform;
+		this.platformUserId = platformUserId;
+		this.primaryEmail = primaryEmail;
+	}
+
+	/**
+	 * SocialAccount 객체 생성 메서드
+	 */
+	public static SocialAccountEntity create(UserEntity user, String platform, String platformUserId, String primaryEmail) {
+		return SocialAccountEntity.builder()
+			.user(user)
+			.platform(platform)
+			.platformUserId(platformUserId)
+			.primaryEmail(primaryEmail)
+			.build();
+	}
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/controller/AuthController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/controller/AuthController.java
@@ -1,15 +1,62 @@
 package org.sopt.pawkey.backendapi.global.auth.api.controller;
 
+import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
+
+import org.sopt.pawkey.backendapi.domain.user.application.facade.UserLoginFacade;
+import org.sopt.pawkey.backendapi.global.auth.api.dto.request.LoginRequestDTO;
+import org.sopt.pawkey.backendapi.global.auth.api.dto.request.RefreshTokenRequestDTO;
+import org.sopt.pawkey.backendapi.global.auth.api.dto.response.TokenResponseDTO;
 import org.sopt.pawkey.backendapi.global.auth.application.service.TokenService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/auth")
+@RequestMapping(API_PREFIX + "/auth")
 public class AuthController {
 
+	private final UserLoginFacade userLoginFacade;
 	private final TokenService tokenService;
+
+	// 1. 소셜 로그인 API
+	@Operation(summary = "Google 소셜 로그인", description = "ID Token을 받아 사용자 인증 및 Access/Refresh Token을 최초 발급합니다.", tags = {"Auth"})
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "최초 토큰 발급 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 요청 데이터 (ID Token 또는 Device ID 누락)", content = @Content(mediaType = "application/json")),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "소셜 토큰 검증 실패 (A40106)", content = @Content(mediaType = "application/json")),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json"))
+	})
+	@PostMapping("/google/login")
+	public TokenResponseDTO googleLogin(@RequestBody @Valid LoginRequestDTO request) {
+		// Facade로 ID Token과 Device ID를 전달하여 모든 인증 및 토큰 발급 로직을 처리
+		return userLoginFacade.googleLogin(request.idToken(), request.deviceId());
+	}
+
+	// 2. 토큰 갱신 API
+	@Operation(summary = "토큰 재발급", description = "Refresh Token과 Device ID를 사용하여 새로운 Access/Refresh Token 쌍을 발급합니다. (토큰 로테이션)", tags = {"Auth"})
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 요청 데이터 (Token 또는 Device ID 누락)", content = @Content(mediaType = "application/json")),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "토큰 무효 (A40102: 만료/유효하지 않음, A40107: 기기 불일치)", content = @Content(mediaType = "application/json")),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json"))
+	})
+	@PostMapping("/refresh")
+
+	public ResponseEntity<TokenResponseDTO> refreshToken(@RequestBody @Valid RefreshTokenRequestDTO request) {
+		// TokenService.rotate 호출 시, RefreshTokenRequestDTO의 필드명에 맞게 호출해야 합니다.
+		// RefreshTokenRequestDTO가 record이므로 필드 접근은 메서드 형태로 (request.refreshToken(), request.deviceId())
+		TokenResponseDTO response = tokenService.rotate(request.refreshToken(), request.deviceId());
+		// ApiResponse 유틸리티를 사용한다고 가정하고 코드를 작성합니다.
+		// return ResponseEntity.ok(ApiResponse.success(response));
+		return ResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/controller/AuthController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/controller/AuthController.java
@@ -1,0 +1,4 @@
+package org.sopt.pawkey.backendapi.global.auth.api.controller;
+
+public class AuthController {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/controller/AuthController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/controller/AuthController.java
@@ -1,4 +1,15 @@
 package org.sopt.pawkey.backendapi.global.auth.api.controller;
 
+import org.sopt.pawkey.backendapi.global.auth.application.service.TokenService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
 public class AuthController {
+
+	private final TokenService tokenService;
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/dto/request/LoginRequestDTO.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/dto/request/LoginRequestDTO.java
@@ -1,0 +1,14 @@
+package org.sopt.pawkey.backendapi.global.auth.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequestDTO(@Schema(description = "소셜 플랫폼으로부터 받은 ID Token", example = "eyJhbGciOiJSUzI1NiIs...")
+							   @NotBlank(message = "ID 토큰은 필수 입력 값입니다.")
+							   String idToken,
+
+							  @Schema(description = "로그인을 시도하는 클라이언트의 고유 기기 ID", example = "abcdef1234567890")
+							   @NotBlank(message = "기기 ID는 필수 입력 값입니다.")
+							   String deviceId
+) {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/dto/request/RefreshRequestDTO.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/dto/request/RefreshRequestDTO.java
@@ -1,5 +1,0 @@
-package org.sopt.pawkey.backendapi.global.auth.api.dto.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record RefreshRequestDTO (@NotBlank String refreshToken) {}

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/dto/request/RefreshRequestDTO.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/dto/request/RefreshRequestDTO.java
@@ -1,4 +1,5 @@
 package org.sopt.pawkey.backendapi.global.auth.api.dto.request;
 
-public class RefreshRequestDTO {
-}
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequestDTO (@NotBlank String refreshToken) {}

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/dto/request/RefreshRequestDTO.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/dto/request/RefreshRequestDTO.java
@@ -1,0 +1,4 @@
+package org.sopt.pawkey.backendapi.global.auth.api.dto.request;
+
+public class RefreshRequestDTO {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/dto/request/RefreshTokenRequestDTO.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/dto/request/RefreshTokenRequestDTO.java
@@ -1,0 +1,12 @@
+package org.sopt.pawkey.backendapi.global.auth.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshTokenRequestDTO(@Schema(description = "만료된 Access Token 대신 사용하는 Refresh Token", example = "eyJhbGciOiJIUzI1NiIs...")
+								 @NotBlank(message = "Refresh Token은 필수 입력 값입니다.")
+								 String refreshToken,
+
+									 @Schema(description = "로그인 시 사용된 클라이언트의 고유 기기 ID", example = "abcdef1234567890")
+								 @NotBlank(message = "기기 ID는 필수 입력 값입니다.")
+								 String deviceId) {}

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/dto/response/TokenResponseDTO.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/dto/response/TokenResponseDTO.java
@@ -1,0 +1,4 @@
+package org.sopt.pawkey.backendapi.global.auth.api.dto.response;
+
+public class TokenResponseDTO {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/dto/response/TokenResponseDTO.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/dto/response/TokenResponseDTO.java
@@ -1,4 +1,3 @@
 package org.sopt.pawkey.backendapi.global.auth.api.dto.response;
 
-public class TokenResponseDTO {
-}
+public record TokenResponseDTO (String accessToken, String refreshToken) {}

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/application/service/TokenService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/application/service/TokenService.java
@@ -1,10 +1,26 @@
 package org.sopt.pawkey.backendapi.global.auth.application.service;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+import org.sopt.pawkey.backendapi.global.auth.api.dto.response.TokenResponseDTO;
+
+import org.sopt.pawkey.backendapi.global.auth.exception.AuthBusinessException;
+import org.sopt.pawkey.backendapi.global.auth.exception.AuthErrorCode;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import lombok.RequiredArgsConstructor;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
 
 @Service
 @RequiredArgsConstructor
@@ -17,9 +33,121 @@ public class TokenService {
 	@Value("${security.jwt.access-exp-minutes}") private long accessExpMinutes;
 	@Value("${security.jwt.refresh-exp-days}") private long refreshExpDays;
 
-	private byte[] keyBytes;
+	private SecretKey signingKey;
 	private static final String REFRESH_PREFIX = "refresh:";
+	private static final String USER_ID_CLAIM = "userId";
+	private static final String DEVICE_ID_CLAIM = "deviceId";
+
+	@PostConstruct
+	public void init() {
+		// 비밀 키를 Base64로 디코딩하여 Key 객체로 변환
+		this.signingKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+	}
+
+	// --- 1. JWT 생성 유틸리티 ---
+
+	/**
+	 * Access Token 또는 Refresh Token을 생성합니다.
+	 */
+	private String createToken(Long userId, String deviceId, long expirationMinutes) {
+		Date now = new Date();
+		Date expiration = new Date(now.getTime() + expirationMinutes * 60 * 1000);
+
+		return Jwts.builder()
+			.setIssuer(issuer)
+			.setIssuedAt(now)
+			.setExpiration(expiration)
+			.claim(USER_ID_CLAIM, userId)
+			.claim(DEVICE_ID_CLAIM, deviceId)
+			.signWith(signingKey, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	/**
+	 * Refresh Token을 Redis에 저장합니다.
+	 */
+	private void saveRefreshToken(Long userId, String deviceId, String refreshToken) {
+		String key = REFRESH_PREFIX + userId + ":" + deviceId;
+		redisTemplate.opsForValue().set(
+			key,
+			refreshToken,
+			Duration.ofDays(refreshExpDays)
+		);
+	}
+
+	// --- 2. 핵심 API 메서드 ---
+
+	/**
+	 * 1. issueTokens: Access Token과 Refresh Token을 발급하고 Refresh Token을 저장합니다.
+	 */
+	public TokenResponseDTO issueTokens(Long userId, String deviceId) {
+		String accessToken = createToken(userId, deviceId, accessExpMinutes);
+		// Refresh Token은 만료 기간을 '일' 단위로 사용
+		String refreshToken = createToken(userId, deviceId, refreshExpDays * 24 * 60);
+
+		saveRefreshToken(userId, deviceId, refreshToken);
+
+		return new TokenResponseDTO(accessToken, refreshToken);
+	}
+
+	/**
+	 * 2. rotate: Refresh Token을 검증하고 새로운 Access/Refresh Token 쌍을 발급합니다.
+	 */
+	public TokenResponseDTO rotate(String oldRefreshToken, String deviceId) {
+		Jws<Claims> claimsJws = validateAndParseToken(oldRefreshToken);
+		Long userId = claimsJws.getBody().get(USER_ID_CLAIM, Long.class);
+		String savedDeviceId = claimsJws.getBody().get(DEVICE_ID_CLAIM, String.class);
+
+		// 1. JWT 내부의 Device ID가 요청된 Device ID와 일치하는지 확인
+		if (!deviceId.equals(savedDeviceId)) {
+			throw new AuthBusinessException(AuthErrorCode.TOKEN_DEVICE_ID_INVALID);
+		}
+
+		String redisKey = REFRESH_PREFIX + userId + ":" + deviceId;
+		String savedToken = redisTemplate.opsForValue().get(redisKey);
+
+		// 2. Redis에 저장된 Refresh Token과 일치하는지 확인 (Token Rotation 검증)
+		if (savedToken == null || !savedToken.equals(oldRefreshToken)) {
+			// Redis에 없거나 토큰이 일치하지 않으면 유효하지 않은 토큰 (이미 폐기되었거나 탈취 시도)
+			throw new AuthBusinessException(AuthErrorCode.REFRESH_TOKEN_INVALID);
+		}
+
+		// 3. 토큰 폐기 및 재발급
+		redisTemplate.delete(redisKey); // 기존 토큰 삭제 (사용 후 폐기)
+		return issueTokens(userId, deviceId); // 새로운 토큰 발급 및 Redis 저장
+	}
+
+	/**
+	 * 3. revoke: 로그아웃 처리 (Refresh Token 삭제)
+	 */
+	public void revoke(Long userId, String deviceId) {
+		String key = REFRESH_PREFIX + userId + ":" + deviceId;
+		redisTemplate.delete(key);
+	}
+
+	// --- 4. JWT 파싱 및 검증 ---
+
+	/**
+	 * JWT를 파싱하고 유효성을 검증합니다.
+	 */
+	public Jws<Claims> validateAndParseToken(String token) {
+		try {
+			// ✅ verifyWith()가 SecretKey 타입을 인식하고 정상 동작
+			return Jwts.parser()
+				.verifyWith(signingKey) // SecretKey 타입으로 오류 해결
+				.build()
+				.parseSignedClaims(token);
+		} catch (Exception e) {
+			throw new AuthBusinessException(AuthErrorCode.REFRESH_TOKEN_INVALID);
+		}
+	}
 
 
-
+	/**
+	 * Access Token에서 사용자 ID를 추출합니다.
+	 */
+	public Long extractUserId(String accessToken) {
+		Jws<Claims> claimsJws = validateAndParseToken(accessToken);
+		return claimsJws.getBody().get(USER_ID_CLAIM, Long.class);
+	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/application/service/TokenService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/application/service/TokenService.java
@@ -1,0 +1,25 @@
+package org.sopt.pawkey.backendapi.global.auth.application.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+	private final StringRedisTemplate redisTemplate;
+
+	@Value("${security.jwt.secret}") private String secret;
+	@Value("${security.jwt.issuer}") private String issuer;
+	@Value("${security.jwt.access-exp-minutes}") private long accessExpMinutes;
+	@Value("${security.jwt.refresh-exp-days}") private long refreshExpDays;
+
+	private byte[] keyBytes;
+	private static final String REFRESH_PREFIX = "refresh:";
+
+
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/application/verifier/GoogleVerifierService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/application/verifier/GoogleVerifierService.java
@@ -8,8 +8,12 @@ import com.nimbusds.jose.proc.JWSKeySelector;
 import com.nimbusds.jose.proc.JWSVerificationKeySelector;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.BadJWTException;
 import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.pawkey.backendapi.global.auth.exception.AuthBusinessException;
@@ -20,99 +24,191 @@ import org.springframework.stereotype.Service;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.ParseException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class GoogleVerifierService {
-	// Google JWKS 엔드포인트 URL
-	private static final String GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs";
 
-	// 서명 알고리즘: Google은 RS256을 사용합니다.
-	private static final Set<JWSAlgorithm> JWS_ALGORITHMS = Collections.singleton(JWSAlgorithm.RS256);
+	private static final String GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs";
 
 	@Value("${social.google.client-id}")
 	private String googleClientId;
 
-	// --- JWKSource 및 JWTProcessor 초기화 ---
-
-	// JWKS 세트 (Google의 공개 키 목록)
 	private JWKSource<SecurityContext> jwkSource;
-
-	// JWT 프로세서: 토큰 검증 로직을 담당
 	private ConfigurableJWTProcessor<SecurityContext> jwtProcessor;
 
-	// @PostConstruct 대신 생성자에서 초기화 (MalformedURLException 처리)
-	public GoogleVerifierService(
-		@Value("${social.google.client-id}") String googleClientId) {
-		this.googleClientId = googleClientId;
+	/**
+	 * 스프링이 @Value 주입 끝낸 후 실행되는 초기화 메서드
+	 */
+	@PostConstruct
+	public void init() {
 		try {
-			// 1. JWK Source 설정: Google의 JWKS URL에서 공개 키 세트를 가져옵니다.
+			// 1. JWK Source 설정
 			this.jwkSource = new RemoteJWKSet<>(new URL(GOOGLE_JWKS_URL));
 
-			// 2. JWT Processor 설정
+			// 2. JWT Processor 생성
 			this.jwtProcessor = new DefaultJWTProcessor<>();
 
-			// 3. JWS 키 선택자 설정: 토큰의 서명 알고리즘(RS256)을 사용하여 키를 선택합니다.
+			// 3. RS256 서명 검증 키 선택자 등록
 			JWSKeySelector<SecurityContext> keySelector =
-				new JWSVerificationKeySelector<>(JWS_ALGORITHMS, jwkSource);
+				new JWSVerificationKeySelector<>(JWSAlgorithm.RS256, jwkSource);
 			this.jwtProcessor.setJWSKeySelector(keySelector);
 
-			// 4. 클레임 검증: 유효성(만료 시간, 발급자, 수신자)을 검증하는 리스너 설정
-			// 발급자(Issuer)는 accounts.google.com 또는 https://accounts.google.com
-			// 수신자(Audience)는 우리 서비스의 Google Client ID
+			// 4. 필수 클레임 + Audience 검증
 			this.jwtProcessor.setJWTClaimsSetVerifier(
-				new com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier(
+				new DefaultJWTClaimsVerifier<>(
 					new JWTClaimsSet.Builder().audience(googleClientId).build(),
-					JWS_ALGORITHMS
+					new HashSet<>(Arrays.asList("sub", "iss", "exp"))
 				)
 			);
 
+			log.info("✅ GoogleVerifierService 초기화 완료 (clientId={})", googleClientId);
+
 		} catch (MalformedURLException e) {
-			log.error("Google JWKS URL이 잘못되었습니다: {}", GOOGLE_JWKS_URL, e);
-			// 서비스 시작 불가 예외 처리 (배포 환경에서 치명적)
-			throw new RuntimeException("Google Verifier 초기화 실패: URL 오류", e);
+			log.error("❌ Google JWKS URL이 잘못되었습니다: {}", GOOGLE_JWKS_URL, e);
+			throw new RuntimeException("Google Verifier 초기화 실패", e);
 		}
 	}
 
-	// --- ID Token 검증 및 정보 추출 메서드 ---
-
+	/**
+	 * 구글 ID Token 검증
+	 */
 	public Map<String, String> verifyGoogleToken(String idToken) {
 		try {
-			// 1. 토큰 검증 및 클레임 추출
 			SecurityContext context = null;
 			JWTClaimsSet claimsSet = jwtProcessor.process(idToken, context);
 
-			// 2. 클레임에서 필요한 정보 추출
-			String platformUserId = claimsSet.getSubject(); // Google의 'sub' 클레임 (고유 ID)
-			String primaryEmail = claimsSet.getStringClaim("email"); // 이메일
-			String emailVerified = claimsSet.getStringClaim("email_verified"); // 이메일 인증 여부
+			String platformUserId = claimsSet.getSubject();
+			String primaryEmail = claimsSet.getStringClaim("email");
+			Boolean emailVerified = claimsSet.getBooleanClaim("email_verified");
 
-			if (!"true".equals(emailVerified)) {
-				log.error("Google ID Token: 인증되지 않은 이메일입니다.");
+			if (emailVerified == null || !emailVerified) {
+				log.error("❌ Google ID Token: 이메일 인증 안됨");
 				throw new AuthBusinessException(AuthErrorCode.SOCIAL_LOGIN_FAIL);
 			}
 
-			// 3. 사용자 정보 맵으로 반환
 			Map<String, String> userInfo = new HashMap<>();
 			userInfo.put("platformUserId", platformUserId);
 			userInfo.put("primaryEmail", primaryEmail);
 			userInfo.put("platform", "GOOGLE");
+
+			log.info("✅ Google ID Token 검증 성공 (sub={}, email={})", platformUserId, primaryEmail);
+
 			return userInfo;
 
 		} catch (ParseException e) {
-			log.error("Google ID Token 파싱 오류: 토큰 형식이 잘못되었습니다.", e);
+			log.error("❌ Google ID Token 파싱 오류", e);
 			throw new AuthBusinessException(AuthErrorCode.ACCESS_TOKEN_INVALID);
 		} catch (BadJOSEException e) {
-			// 서명 오류, 만료, audience 불일치 등 유효성 검증 실패
-			log.error("Google ID Token 유효성 검증 실패: {}", e.getMessage(), e);
+			log.error("❌ Google ID Token 검증 실패: {}", e.getMessage());
 			throw new AuthBusinessException(AuthErrorCode.SOCIAL_LOGIN_FAIL);
 		} catch (Exception e) {
-			log.error("Google ID Token 검증 중 예상치 못한 오류 발생", e);
+			log.error("❌ Google ID Token 검증 중 예외 발생", e);
 			throw new AuthBusinessException(AuthErrorCode.SOCIAL_LOGIN_FAIL);
 		}
 	}
 }
+
+
+// @Slf4j
+// @Service
+// @RequiredArgsConstructor
+// public class GoogleVerifierService {
+// 	// Google JWKS 엔드포인트 URL
+// 	private static final String GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs";
+//
+// 	// 서명 알고리즘: Google은 RS256을 사용합니다.
+// 	private static final Set<JWSAlgorithm> JWS_ALGORITHMS = Collections.singleton(JWSAlgorithm.RS256);
+//
+// 	@Value("${social.google.client-id}")
+// 	private String googleClientId;
+//
+// 	// --- JWKSource 및 JWTProcessor 초기화 ---
+//
+// 	// JWKS 세트 (Google의 공개 키 목록)
+// 	private JWKSource<SecurityContext> jwkSource;
+//
+// 	// JWT 프로세서: 토큰 검증 로직을 담당
+// 	private ConfigurableJWTProcessor<SecurityContext> jwtProcessor;
+//
+// 	// @PostConstruct 대신 생성자에서 초기화 (MalformedURLException 처리)
+// 	public GoogleVerifierService(
+// 		@Value("${social.google.client-id}") String googleClientId) {
+// 		this.googleClientId = googleClientId;
+// 		try {
+// 			// 1. JWK Source 설정: Google의 JWKS URL에서 공개 키 세트를 가져옵니다.
+// 			this.jwkSource = new RemoteJWKSet<>(new URL(GOOGLE_JWKS_URL));
+//
+// 			// 2. JWT Processor 설정
+// 			this.jwtProcessor = new DefaultJWTProcessor<>();
+//
+// 			// 3. JWS 키 선택자 설정: 토큰의 서명 알고리즘(RS256)을 사용하여 키를 선택합니다.
+// 			JWSKeySelector<SecurityContext> keySelector =
+// 				new JWSVerificationKeySelector<>(JWS_ALGORITHMS, jwkSource);
+// 			this.jwtProcessor.setJWSKeySelector(keySelector);
+//
+// 			// 4. 클레임 검증: 유효성(만료 시간, 발급자, 수신자)을 검증하는 리스너 설정
+// 			// 발급자(Issuer)는 accounts.google.com 또는 https://accounts.google.com
+// 			// 수신자(Audience)는 우리 서비스의 Google Client ID
+// 			this.jwtProcessor.setJWTClaimsSetVerifier(
+// 				new DefaultJWTClaimsVerifier<>(
+// 					new JWTClaimsSet.Builder().audience(googleClientId).build(),
+// 					new HashSet<>(Arrays.asList("sub", "iss", "exp")) // 필수 클레임 지정
+// 				)
+// 			);
+//
+// 		} catch (MalformedURLException e) {
+// 			log.error("Google JWKS URL이 잘못되었습니다: {}", GOOGLE_JWKS_URL, e);
+// 			// 서비스 시작 불가 예외 처리 (배포 환경에서 치명적)
+// 			throw new RuntimeException("Google Verifier 초기화 실패: URL 오류", e);
+// 		}
+// 	}
+//
+// 	// --- ID Token 검증 및 정보 추출 메서드 ---
+//
+// 	public Map<String, String> verifyGoogleToken(String idToken) {
+// 		try {
+// 			// 1. 토큰 검증 및 클레임 추출
+// 			SecurityContext context = null;
+// 			JWTClaimsSet claimsSet = jwtProcessor.process(idToken, context);
+//
+// 			// 2. 클레임에서 필요한 정보 추출
+// 			String platformUserId = claimsSet.getSubject(); // Google의 'sub' 클레임 (고유 ID)
+// 			String primaryEmail = claimsSet.getStringClaim("email"); // 이메일
+// 			Boolean emailVerified = claimsSet.getBooleanClaim("email_verified");
+// 			if (emailVerified == null || !emailVerified) {
+// 				throw new AuthBusinessException(AuthErrorCode.SOCIAL_LOGIN_FAIL);
+// 			}
+//
+// 			if (!"true".equals(emailVerified)) {
+// 				log.error("Google ID Token: 인증되지 않은 이메일입니다.");
+// 				throw new AuthBusinessException(AuthErrorCode.SOCIAL_LOGIN_FAIL);
+// 			}
+//
+// 			// 3. 사용자 정보 맵으로 반환
+// 			Map<String, String> userInfo = new HashMap<>();
+// 			userInfo.put("platformUserId", platformUserId);
+// 			userInfo.put("primaryEmail", primaryEmail);
+// 			userInfo.put("platform", "GOOGLE");
+// 			return userInfo;
+//
+// 		} catch (ParseException e) {
+// 			log.error("Google ID Token 파싱 오류: 토큰 형식이 잘못되었습니다.", e);
+// 			throw new AuthBusinessException(AuthErrorCode.ACCESS_TOKEN_INVALID);
+// 		} catch (BadJOSEException e) {
+// 			// 서명 오류, 만료, audience 불일치 등 유효성 검증 실패
+// 			log.error("Google ID Token 유효성 검증 실패: {}", e.getMessage(), e);
+// 			throw new AuthBusinessException(AuthErrorCode.SOCIAL_LOGIN_FAIL);
+// 		} catch (Exception e) {
+// 			log.error("Google ID Token 검증 중 예상치 못한 오류 발생", e);
+// 			throw new AuthBusinessException(AuthErrorCode.SOCIAL_LOGIN_FAIL);
+// 		}
+// 	}
+// }

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/application/verifier/GoogleVerifierService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/application/verifier/GoogleVerifierService.java
@@ -1,0 +1,118 @@
+package org.sopt.pawkey.backendapi.global.auth.application.verifier;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.JWSKeySelector;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.pawkey.backendapi.global.auth.exception.AuthBusinessException;
+import org.sopt.pawkey.backendapi.global.auth.exception.AuthErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.ParseException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GoogleVerifierService {
+	// Google JWKS 엔드포인트 URL
+	private static final String GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs";
+
+	// 서명 알고리즘: Google은 RS256을 사용합니다.
+	private static final Set<JWSAlgorithm> JWS_ALGORITHMS = Collections.singleton(JWSAlgorithm.RS256);
+
+	@Value("${social.google.client-id}")
+	private String googleClientId;
+
+	// --- JWKSource 및 JWTProcessor 초기화 ---
+
+	// JWKS 세트 (Google의 공개 키 목록)
+	private JWKSource<SecurityContext> jwkSource;
+
+	// JWT 프로세서: 토큰 검증 로직을 담당
+	private ConfigurableJWTProcessor<SecurityContext> jwtProcessor;
+
+	// @PostConstruct 대신 생성자에서 초기화 (MalformedURLException 처리)
+	public GoogleVerifierService(
+		@Value("${social.google.client-id}") String googleClientId) {
+		this.googleClientId = googleClientId;
+		try {
+			// 1. JWK Source 설정: Google의 JWKS URL에서 공개 키 세트를 가져옵니다.
+			this.jwkSource = new RemoteJWKSet<>(new URL(GOOGLE_JWKS_URL));
+
+			// 2. JWT Processor 설정
+			this.jwtProcessor = new DefaultJWTProcessor<>();
+
+			// 3. JWS 키 선택자 설정: 토큰의 서명 알고리즘(RS256)을 사용하여 키를 선택합니다.
+			JWSKeySelector<SecurityContext> keySelector =
+				new JWSVerificationKeySelector<>(JWS_ALGORITHMS, jwkSource);
+			this.jwtProcessor.setJWSKeySelector(keySelector);
+
+			// 4. 클레임 검증: 유효성(만료 시간, 발급자, 수신자)을 검증하는 리스너 설정
+			// 발급자(Issuer)는 accounts.google.com 또는 https://accounts.google.com
+			// 수신자(Audience)는 우리 서비스의 Google Client ID
+			this.jwtProcessor.setJWTClaimsSetVerifier(
+				new com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier(
+					new JWTClaimsSet.Builder().audience(googleClientId).build(),
+					JWS_ALGORITHMS
+				)
+			);
+
+		} catch (MalformedURLException e) {
+			log.error("Google JWKS URL이 잘못되었습니다: {}", GOOGLE_JWKS_URL, e);
+			// 서비스 시작 불가 예외 처리 (배포 환경에서 치명적)
+			throw new RuntimeException("Google Verifier 초기화 실패: URL 오류", e);
+		}
+	}
+
+	// --- ID Token 검증 및 정보 추출 메서드 ---
+
+	public Map<String, String> verifyGoogleToken(String idToken) {
+		try {
+			// 1. 토큰 검증 및 클레임 추출
+			SecurityContext context = null;
+			JWTClaimsSet claimsSet = jwtProcessor.process(idToken, context);
+
+			// 2. 클레임에서 필요한 정보 추출
+			String platformUserId = claimsSet.getSubject(); // Google의 'sub' 클레임 (고유 ID)
+			String primaryEmail = claimsSet.getStringClaim("email"); // 이메일
+			String emailVerified = claimsSet.getStringClaim("email_verified"); // 이메일 인증 여부
+
+			if (!"true".equals(emailVerified)) {
+				log.error("Google ID Token: 인증되지 않은 이메일입니다.");
+				throw new AuthBusinessException(AuthErrorCode.SOCIAL_LOGIN_FAIL);
+			}
+
+			// 3. 사용자 정보 맵으로 반환
+			Map<String, String> userInfo = new HashMap<>();
+			userInfo.put("platformUserId", platformUserId);
+			userInfo.put("primaryEmail", primaryEmail);
+			userInfo.put("platform", "GOOGLE");
+			return userInfo;
+
+		} catch (ParseException e) {
+			log.error("Google ID Token 파싱 오류: 토큰 형식이 잘못되었습니다.", e);
+			throw new AuthBusinessException(AuthErrorCode.ACCESS_TOKEN_INVALID);
+		} catch (BadJOSEException e) {
+			// 서명 오류, 만료, audience 불일치 등 유효성 검증 실패
+			log.error("Google ID Token 유효성 검증 실패: {}", e.getMessage(), e);
+			throw new AuthBusinessException(AuthErrorCode.SOCIAL_LOGIN_FAIL);
+		} catch (Exception e) {
+			log.error("Google ID Token 검증 중 예상치 못한 오류 발생", e);
+			throw new AuthBusinessException(AuthErrorCode.SOCIAL_LOGIN_FAIL);
+		}
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/application/verifier/VerifierService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/application/verifier/VerifierService.java
@@ -1,0 +1,7 @@
+package org.sopt.pawkey.backendapi.global.auth.application.verifier;
+
+import java.util.Map;
+
+public interface  VerifierService {
+	Map<String, String> verifyToken(String platform, String idToken);
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/exception/AuthBusinessException.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/exception/AuthBusinessException.java
@@ -1,0 +1,7 @@
+package org.sopt.pawkey.backendapi.global.auth.exception;
+
+public class AuthBusinessException extends RuntimeException {
+	public AuthBusinessException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/exception/AuthBusinessException.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/exception/AuthBusinessException.java
@@ -1,7 +1,12 @@
 package org.sopt.pawkey.backendapi.global.auth.exception;
 
-public class AuthBusinessException extends RuntimeException {
-	public AuthBusinessException(String message) {
-		super(message);
+import org.sopt.pawkey.backendapi.global.exception.BusinessException;
+import org.sopt.pawkey.backendapi.global.exception.ErrorCode;
+
+public class AuthBusinessException extends BusinessException {
+	public AuthBusinessException(ErrorCode errorCode) {
+
+		super(errorCode);
+
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/exception/AuthErrorCode.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/exception/AuthErrorCode.java
@@ -1,0 +1,43 @@
+package org.sopt.pawkey.backendapi.global.auth.exception;
+
+import org.sopt.pawkey.backendapi.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public enum AuthErrorCode implements ErrorCode {
+
+	// JWT/Token 관련 오류
+	ACCESS_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "A40101", "유효하지 않은 Access Token입니다."),
+	REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "A40102", "유효하지 않거나 만료된 Refresh Token입니다."),
+	TOKEN_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "A40103", "토큰 서명이 유효하지 않습니다."),
+	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A40104", "토큰이 만료되었습니다."),
+	TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "A40105", "인증 토큰이 누락되었습니다."),
+
+
+	// 소셜 로그인 관련 오류
+	SOCIAL_LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "A40106", "소셜 로그인 인증에 실패했습니다. (외부 서버 오류 등)"),
+	SOCIAL_ID_INVALID(HttpStatus.BAD_REQUEST, "A40001", "소셜 프로바이더로부터 유효한 ID를 얻지 못했습니다.");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+
+	@Override
+	public String getCode() {
+		return code;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return status;
+	}
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/exception/AuthErrorCode.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/exception/AuthErrorCode.java
@@ -15,7 +15,7 @@ public enum AuthErrorCode implements ErrorCode {
 	TOKEN_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "A40103", "토큰 서명이 유효하지 않습니다."),
 	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A40104", "토큰이 만료되었습니다."),
 	TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "A40105", "인증 토큰이 누락되었습니다."),
-
+	TOKEN_DEVICE_ID_INVALID(HttpStatus.UNAUTHORIZED, "A40107", "요청된 기기 ID와 토큰 내부의 기기 ID가 일치하지 않습니다."),
 
 	// 소셜 로그인 관련 오류
 	SOCIAL_LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "A40106", "소셜 로그인 인증에 실패했습니다. (외부 서버 오류 등)"),

--- a/src/main/java/org/sopt/pawkey/backendapi/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/config/SecurityConfig.java
@@ -14,7 +14,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
-import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;

--- a/src/main/java/org/sopt/pawkey/backendapi/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/config/SecurityConfig.java
@@ -33,8 +33,8 @@ public class SecurityConfig {
 			.csrf(csrf -> csrf.disable())
 			.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/auth/**",
-					"/health",
+				.requestMatchers(
+					"/api/v1/**",
 					"/v3/api-docs/**",
 					"/swagger-ui/**",
 					"/swagger-ui.html").permitAll()

--- a/src/main/java/org/sopt/pawkey/backendapi/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/config/SecurityConfig.java
@@ -1,0 +1,61 @@
+package org.sopt.pawkey.backendapi.global.config;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	//HTTP 보안 설정: 세션 비활성화 & JWT 인증 설정
+	@Bean
+	SecurityFilterChain filterChain(HttpSecurity http, JwtDecoder jwtDecoder) throws Exception{
+		return http
+			.csrf(csrf -> csrf.disable())
+			.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/auth/**", "/health").permitAll()
+				.anyRequest().authenticated()
+			)
+			.oauth2ResourceServer(oauth -> oauth.jwt(jwt -> jwt.decoder(jwtDecoder)))
+			.build();
+	}
+
+	//JWT 디코더 설정: (application-oauth.yml)secret 값으로 HS256 서명 검증
+	@Bean
+	JwtDecoder jwtDecoder(@Value("${security.jwt.secret}") String secret) {
+		// 대칭키 (HS256) 생성
+		SecretKey key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"); //대칭키 (HS256) 생성
+
+		OAuth2TokenValidator<org.springframework.security.oauth2.jwt.Jwt> validator =
+			new DelegatingOAuth2TokenValidator<>(
+				new JwtTimestampValidator(Duration.ofSeconds(60)) // 시계 오차 60초 허용
+			);
+		NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withSecretKey(key)
+			.build();
+
+		jwtDecoder.setJwtValidator(validator);
+
+		return jwtDecoder;
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/config/SecurityConfig.java
@@ -33,7 +33,11 @@ public class SecurityConfig {
 			.csrf(csrf -> csrf.disable())
 			.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/auth/**", "/health").permitAll()
+				.requestMatchers("/auth/**",
+					"/health",
+					"/v3/api-docs/**",
+					"/swagger-ui/**",
+					"/swagger-ui.html").permitAll()
 				.anyRequest().authenticated()
 			)
 			.oauth2ResourceServer(oauth -> oauth.jwt(jwt -> jwt.decoder(jwtDecoder)))

--- a/src/main/java/org/sopt/pawkey/backendapi/global/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/config/SwaggerConfig.java
@@ -8,8 +8,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 
 @Configuration
@@ -36,6 +39,13 @@ public class SwaggerConfig {
 			.info(new Info()
 				.title("paw-key API")
 				.version("v1")
-				.description("paw-key API 명세서"));
+				.description("paw-key API 명세서"))
+				.components(new Components()
+				.addSecuritySchemes("bearerAuth",
+					new SecurityScheme()
+						.type(SecurityScheme.Type.HTTP)
+						.scheme("bearer")
+						.bearerFormat("JWT")))
+			.addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/global/config/interceptor/UserHeaderInterceptor.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/config/interceptor/UserHeaderInterceptor.java
@@ -15,6 +15,16 @@ public class UserHeaderInterceptor implements HandlerInterceptor {
 
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+		String uri = request.getRequestURI();
+
+		// 로그인/토큰 재발급 같은 공개 엔드포인트는 헤더 검사 스킵
+		if (uri.startsWith("/api/v1/auth")) {
+			return true;
+		}
+		if (uri.startsWith("/api/v1/posts")) {
+			return true;
+		}
+
 		String userId = request.getHeader(USER_ID_HEADER);
 		if (userId == null || userId.isBlank()) {
 			throw new BusinessException(GlobalErrorCode.MISSING_REQUIRED_HEADER);
@@ -26,3 +36,4 @@ public class UserHeaderInterceptor implements HandlerInterceptor {
 		return true;
 	}
 }
+


### PR DESCRIPTION
## 📌 PR 제목
ex) [feat] 공통 로직 구현
ex) [feat] Google 소셜 로그인 및 JWT 인증 체계 구축

---

## ✨ 요약 설명
구글 ID Token을 검증해 회원을 식별하고, 자체 JWT를 발급·검증할 수 있는 인증 체계를 추가했습니다.
기존 user-x-header 기반 요청 흐름은 제거하고, 이제 모든 API는 Bearer Token을 통해 인증받도록 변경되었습니다.

---

## 🧾 변경 사항

### 1. GoogleVerifierService 구현

- Google JWKS를 활용하여 RS256 서명 검증 및 클레임 검증을 처리하였습니다.
- sub, email, email_verified 등 필수 클레임을 검증하고 사용자 계정과 매핑하도록 구현하였습니다.

### 2. AuthController 추가

- /api/v1/auth/google/login : 최초 로그인 및 회원가입을 동시에 처리하는 엔드포인트를 추가하였습니다.
- /api/v1/auth/refresh : Refresh Token을 통한 AccessToken 재발급 API를 구현하였습니다.


### 3. TokenService 구현

- JWT 발급, 파싱, 유효성 검증, 토큰 로테이션을 담당합니다.
- AccessToken은 짧은 유효기간(30분), RefreshToken은 긴 유효기간(14일)을 갖도록 설계했습니다.
- Redis에 RefreshToken과 기기 정보(DeviceId)를 저장하여 토큰 탈취·재사용 공격을 방지합니다.

### 4. SecurityConfig 구현 및 리팩토링

- JWT 인증을 적용했습니다.
- Swagger, 로그인/재발급 API 등 공개 엔드포인트는 permitAll로 열어두었습니다.
- 나머지 API는 JWT 인증이 반드시 필요합니다.


### 5. Swagger 문서화 개선

- Bearer Token 인증 스키마를 추가하여 Swagger UI에서도 토큰을 입력하고 테스트할 수 있도록 변경했습니다.

---

## 📂 PR 타입
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Swagger로 API 호출 확인

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 리뷰할 때 집중해서 봐주었으면 하는 부분
- 고민 중인 로직 또는 개선점 등

## 📌 앞으로 해야 할 작업 (TODO)

### 1. JwtAuthenticationFilter 전역 적용

모든 요청에서 Authorization: Bearer <token> 헤더를 자동 파싱/검증하도록 필터를 추가 예정입니다.

### 2. UserHeaderInterceptor 제거

기존 X-USER-ID 기반 인증 방식을 완전히 제거하고, JWT 인증으로 통일해야합니다.

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #164 
- Fix #이슈번호