### PR TITLE
[feat] 카카오 로그인 로직 추상화

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/UserLoginFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/UserLoginFacade.java
@@ -6,6 +6,7 @@ import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
 import org.sopt.pawkey.backendapi.global.auth.api.dto.response.TokenResponseDTO;
 import org.sopt.pawkey.backendapi.global.auth.application.service.TokenService;
 import org.sopt.pawkey.backendapi.global.auth.application.verifier.GoogleVerifierService;
+import org.sopt.pawkey.backendapi.global.auth.application.verifier.KakaoVerifierService;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -17,11 +18,10 @@ public class UserLoginFacade {
 	private final UserService userService;
 	private final TokenService tokenService;
 	private final GoogleVerifierService googleVerifierService;
+	private final KakaoVerifierService kakaoVerifierService;
 	public TokenResponseDTO googleLogin(String idToken, String deviceId) {
 
 		Map<String, String> socialUserInfo = googleVerifierService.verifyGoogleToken(idToken);
-
-
 
 		String platformUserId = "dummyGoogleId12345";
 		String primaryEmail = "dummy@google.com";
@@ -33,4 +33,15 @@ public class UserLoginFacade {
 		return tokenService.issueTokens(userId, deviceId);
 	}
 
+	public TokenResponseDTO kakaoLogin(String accessToken, String deviceId) {
+		Map<String, String> socialUserInfo = kakaoVerifierService.verifyKakaoToken(accessToken);
+
+		Long userId = userService.findOrCreateUserBySocialId(
+			socialUserInfo.get("platform"),
+			socialUserInfo.get("platformUserId"),
+			socialUserInfo.get("primaryEmail")
+		);
+
+		return tokenService.issueTokens(userId, deviceId);
+	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/UserLoginFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/UserLoginFacade.java
@@ -18,20 +18,18 @@ public class UserLoginFacade {
 	private final TokenService tokenService;
 	private final GoogleVerifierService googleVerifierService;
 	public TokenResponseDTO googleLogin(String idToken, String deviceId) {
-		// 1. 외부 시스템 연동 (Verifier는 4단계에서 구현 예정)
+
 		Map<String, String> socialUserInfo = googleVerifierService.verifyGoogleToken(idToken);
 
 
-		// 임시 더미 데이터 (Verifier 구현 전까지 사용)
+
 		String platformUserId = "dummyGoogleId12345";
 		String primaryEmail = "dummy@google.com";
 
-		// 2. 비즈니스 처리 (User 생성/조회)
-		// UserService는 User와 SocialAccount의 DB 트랜잭션만 책임집니다.
+
 		Long userId = userService.findOrCreateUserBySocialId("GOOGLE", platformUserId, primaryEmail);
 
-		// 3. 인프라 처리 (토큰 발급 및 Redis 저장)
-		// TokenService는 AccessToken과 RefreshToken이 담긴 DTO를 반환합니다.
+
 		return tokenService.issueTokens(userId, deviceId);
 	}
 

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/controller/AuthController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/controller/AuthController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -58,5 +59,19 @@ public class AuthController {
 		// ApiResponse 유틸리티를 사용한다고 가정하고 코드를 작성합니다.
 		// return ResponseEntity.ok(ApiResponse.success(response));
 		return ResponseEntity.ok(response);
+	}
+
+	// 3. 카카오 로그인 API
+	@Operation(summary = "Kakao 소셜 로그인", description = "Access Token을 받아 사용자 인증 및 Access/Refresh Token을 최초 발급합니다.", tags = {"Auth"})
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "최초 토큰 발급 성공"),
+		@ApiResponse(responseCode = "400", description = "유효하지 않은 요청 데이터 (Access Token 또는 Device ID 누락)", content = @Content(mediaType = "application/json")),
+		@ApiResponse(responseCode = "401", description = "소셜 토큰 검증 실패 (A40106)", content = @Content(mediaType = "application/json")),
+		@ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json"))
+	})
+	@PostMapping("/kakao/login")
+	public TokenResponseDTO kakaoLogin(@RequestBody @Valid LoginRequestDTO request) {
+		// 카카오는 idToken 대신 Access Token을 받으므로 request.idToken() -> accessToken 개념임
+		return userLoginFacade.kakaoLogin(request.idToken(), request.deviceId());
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/application/verifier/KakaoVerifierService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/application/verifier/KakaoVerifierService.java
@@ -1,0 +1,13 @@
+package org.sopt.pawkey.backendapi.global.auth.application.verifier;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoVerifierService {
+
+
+
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/application/verifier/KakaoVerifierService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/application/verifier/KakaoVerifierService.java
@@ -1,6 +1,14 @@
 package org.sopt.pawkey.backendapi.global.auth.application.verifier;
 
+import java.net.http.HttpHeaders;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 import lombok.RequiredArgsConstructor;
 
@@ -8,6 +16,32 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class KakaoVerifierService {
 
+	private final RestTemplate restTemplate = new RestTemplate();
 
+	@Value("${social.kakao.userme-uri}")
+	private String kakaoUserMeUri;
 
+	public Map<String, String> verifyKakaoToken(String accessToken) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setBearerAuth(accessToken);
+		HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+		ResponseEntity<Map> response =
+			restTemplate.exchange(kakaoUserMeUri, HttpMethod.GET, entity, Map.class);
+
+		Map<String, Object> body = response.getBody();
+		if (body == null) throw new RuntimeException("카카오 응답이 비어 있음");
+
+		Map<String, Object> account = (Map<String, Object>) body.get("kakao_account");
+		String email = (String) account.get("email");
+		Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+		Map<String, String> userInfo = new HashMap<>();
+		userInfo.put("platformUserId", String.valueOf(body.get("id")));
+		userInfo.put("primaryEmail", email);
+		userInfo.put("nickname", (String) profile.get("nickname"));
+		userInfo.put("platform", "KAKAO");
+
+		return userInfo;
+	}
 }


### PR DESCRIPTION
## 📌 PR 제목
[feat] 카카오 로그인 로직 추상화

---

## ✨ 요약 설명
- 카카오 로그인 플로우에 필요한 기본 API 엔드포인트를 임시로 구현하였습니다.
= 카카오 Access Token을 받아 사용자 정보를 조회하는 로직까지 적용하였습니다.
= 전역 X-USER-ID 제거 후, JWT 필터 적용은 다음 단계에서 진행 예정입니다.

---

## 🧾 변경 사항
- 무엇을 추가/수정/삭제했나요?
- 어떤 파일 또는 모듈이 변경되었나요?

---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 현재 카카오 로그인 API는 임시 구현 버전입니다.
- X-USER-ID 제거 및 JWT 인증 필터 적용 이후, 카카오 로그인 로직 테스트와 함께 최종적으로 안정화할 계획입니다.

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #166 
- Fix #이슈번호